### PR TITLE
Add healthcheck function to abstract driver and implementations

### DIFF
--- a/graph/driver/driver.go
+++ b/graph/driver/driver.go
@@ -11,6 +11,7 @@ var ErrNotFound = errors.New("not found")
 
 type Driver interface {
 	Close(ctx context.Context) error
+	Healthcheck() (string, error)
 }
 
 type CodeList interface {

--- a/mock/driver.go
+++ b/mock/driver.go
@@ -15,6 +15,10 @@ func (m *Mock) Close(ctx context.Context) error {
 	return nil
 }
 
+func (m *Mock) Healthcheck() (string, error) {
+	return "mock", nil
+}
+
 func (m *Mock) checkForErrors() error {
 	if m.IsBackendReachable != true {
 		return errors.New("database unavailble - 500")

--- a/neo4j/driver/driver.go
+++ b/neo4j/driver/driver.go
@@ -17,6 +17,7 @@ type Neo4jDriver interface {
 	Count(query string) (count int64, err error)
 	Exec(query string, params map[string]interface{}) error
 	Close(ctx context.Context) error
+	Healthcheck() (string, error)
 }
 
 type NeoDriver struct {

--- a/neo4j/driver/healthcheck.go
+++ b/neo4j/driver/healthcheck.go
@@ -1,0 +1,22 @@
+package driver
+
+const serviceName = "neo4j"
+const pingStmt = "MATCH (i) RETURN i LIMIT 1"
+
+// Healthcheck calls neo4j to check its health status.
+func (n *NeoDriver) Healthcheck() (string, error) {
+
+	conn, err := n.pool.OpenPool()
+	if err != nil {
+		return serviceName, err
+	}
+	defer conn.Close()
+
+	rows, err := conn.QueryNeo(pingStmt, nil)
+	if err != nil {
+		return serviceName, err
+	}
+	defer rows.Close()
+
+	return serviceName, nil
+}


### PR DESCRIPTION
### What

- add healthcheck function to interface
- add healthcheck implementations

allows apps to healthcheck whether their configured graph is reachable throughout the life of the app

healthcheck function satisfies existing implementations in go-ns

### How to review

check healthcheck function can be call for each implementation

### Who can review

anyone