### PR TITLE
Add InsertObservationBatch function and neo4j implementation

### DIFF
--- a/graph/driver/driver.go
+++ b/graph/driver/driver.go
@@ -3,14 +3,35 @@ package driver
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	codelistModels "github.com/ONSdigital/dp-code-list-api/models"
 	importModels "github.com/ONSdigital/dp-dimension-importer/model"
 	"github.com/ONSdigital/dp-graph/observation"
 	hierarchyModels "github.com/ONSdigital/dp-hierarchy-api/models"
+	obsModels "github.com/ONSdigital/dp-observation-importer/models"
 )
 
 var ErrNotFound = errors.New("not found")
+
+// ErrAttemptsExceededLimit is returned when the number of attempts has reaced
+// the maximum permitted
+type ErrAttemptsExceededLimit struct {
+	WrappedErr error
+}
+
+func (e ErrAttemptsExceededLimit) Error() string {
+	return fmt.Sprintf("number of attempts to execute statement exceeded: %s", e.WrappedErr.Error())
+}
+
+// ErrNonRetriable is returned when the wrapped error type is not retriable
+type ErrNonRetriable struct {
+	WrappedErr error
+}
+
+func (e ErrNonRetriable) Error() string {
+	return fmt.Sprintf("received a non retriable error from neo4j: %s", e.WrappedErr.Error())
+}
 
 type Driver interface {
 	Close(ctx context.Context) error
@@ -46,6 +67,7 @@ type Hierarchy interface {
 // Observation provides filtered observation data in CSV rows.
 type Observation interface {
 	StreamCSVRows(ctx context.Context, filter *observation.Filter, limit *int) (observation.StreamRowReader, error)
+	InsertObservationBatch(ctx context.Context, attempt int, instanceID string, observations []*obsModels.Observation, dimensionIDs map[string]string) error
 }
 
 type Instance interface {

--- a/mock/observation.go
+++ b/mock/observation.go
@@ -4,8 +4,13 @@ import (
 	"context"
 
 	"github.com/ONSdigital/dp-graph/observation"
+	"github.com/ONSdigital/dp-observation-importer/models"
 )
 
 func (m *Mock) StreamCSVRows(ctx context.Context, filter *observation.Filter, limit *int) (observation.StreamRowReader, error) {
 	return nil, m.checkForErrors()
+}
+
+func (m *Mock) InsertObservationBatch(ctx context.Context, attempt int, instanceID string, observations []*models.Observation, dimensionIDs map[string]string) error {
+	return m.checkForErrors()
 }

--- a/neo4j/hierarchy_test.go
+++ b/neo4j/hierarchy_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"testing"
 
+	graph "github.com/ONSdigital/dp-graph/graph/driver"
 	"github.com/ONSdigital/dp-graph/neo4j/internal"
 	bolt "github.com/ONSdigital/golang-neo4j-bolt-driver"
 	neoErrors "github.com/ONSdigital/golang-neo4j-bolt-driver/errors"
@@ -72,7 +73,7 @@ func Test_CreateInstanceHierarchyConstraints_NeoExecErr(t *testing.T) {
 			})
 
 			Convey("Then the returned error should be that returned from the exec call", func() {
-				So(err, ShouldEqual, execErr)
+				So(err, ShouldResemble, graph.ErrNonRetriable{execErr})
 			})
 		})
 	})
@@ -98,7 +99,7 @@ func TestStore_CreateInstanceHierarchyConstraints_NeoExecRetry(t *testing.T) {
 			})
 
 			Convey("Then the returned error should wrap that returned from the exec call", func() {
-				So(err, ShouldResemble, ErrAttemptsExceededLimit{transientNeoErr})
+				So(err, ShouldResemble, graph.ErrAttemptsExceededLimit{transientNeoErr})
 			})
 		})
 	})
@@ -157,7 +158,7 @@ func TestStore_CloneNodes_NeoExecErr(t *testing.T) {
 			})
 
 			Convey("Then the returned error should be that returned from the exec call", func() {
-				So(err, ShouldEqual, execErr)
+				So(err, ShouldResemble, graph.ErrNonRetriable{execErr})
 			})
 		})
 	})
@@ -223,7 +224,7 @@ func TestStore_CloneRelationships_NeoExecErr(t *testing.T) {
 			})
 
 			Convey("Then the returned error should be that returned from the exec call", func() {
-				So(err, ShouldEqual, execErr)
+				So(err, ShouldResemble, graph.ErrNonRetriable{execErr})
 			})
 		})
 	})
@@ -283,7 +284,7 @@ func TestStore_SetNumberOfChildren_NeoExecErr(t *testing.T) {
 			})
 
 			Convey("Then the returned error should be that returned from the exec call", func() {
-				So(err, ShouldEqual, execErr)
+				So(err, ShouldResemble, graph.ErrNonRetriable{execErr})
 			})
 		})
 	})
@@ -342,7 +343,7 @@ func TestStore_SetHasData_NeoExecErr(t *testing.T) {
 			})
 
 			Convey("Then the returned error should be that returned from the exec call", func() {
-				So(err, ShouldEqual, execErr)
+				So(err, ShouldResemble, graph.ErrNonRetriable{execErr})
 			})
 		})
 	})
@@ -401,7 +402,7 @@ func TestStore_MarkNodesToRemain_NeoExecErr(t *testing.T) {
 			})
 
 			Convey("Then the returned error should be that returned from the exec call", func() {
-				So(err, ShouldEqual, execErr)
+				So(err, ShouldResemble, graph.ErrNonRetriable{execErr})
 			})
 		})
 	})
@@ -457,7 +458,7 @@ func TestStore_RemoveNodesNotMarkedToRemain_NeoExecErr(t *testing.T) {
 			})
 
 			Convey("Then the returned error should be that returned from the exec call", func() {
-				So(err, ShouldEqual, execErr)
+				So(err, ShouldResemble, graph.ErrNonRetriable{execErr})
 			})
 		})
 	})
@@ -513,7 +514,7 @@ func TestStore_RemoveRemainMarker_NeoExecErr(t *testing.T) {
 			})
 
 			Convey("Then the returned error should be that returned from the exec call", func() {
-				So(err, ShouldEqual, execErr)
+				So(err, ShouldResemble, graph.ErrNonRetriable{execErr})
 			})
 		})
 	})

--- a/neo4j/neo4j.go
+++ b/neo4j/neo4j.go
@@ -1,12 +1,12 @@
 package neo4j
 
 import (
-	"fmt"
 	"math"
 	"math/rand"
 	"strings"
 	"time"
 
+	graph "github.com/ONSdigital/dp-graph/graph/driver"
 	"github.com/ONSdigital/dp-graph/neo4j/driver"
 	"github.com/ONSdigital/go-ns/log"
 	neoErrors "github.com/ONSdigital/golang-neo4j-bolt-driver/errors"
@@ -48,28 +48,18 @@ func New(dbAddr string, size, timeout, retries int) (n *Neo4j, err error) {
 	}, nil
 }
 
-// ErrAttemptsExceededLimit is returned when the number of attempts has reaced
-// the maximum permitted
-type ErrAttemptsExceededLimit struct {
-	WrappedErr error
-}
-
-func (e ErrAttemptsExceededLimit) Error() string {
-	return fmt.Sprintf("number of attempts to execute statement exceeded: %s", e.WrappedErr.Error())
-}
-
 func (n *Neo4j) checkAttempts(err error, instanceID string, attempt int) error {
 	if !isTransientError(err) {
 		log.Info("received an error from neo4j that cannot be retried",
 			log.Data{"instance_id": instanceID, "error": err})
 
-		return err
+		return graph.ErrNonRetriable{err}
 	}
 
 	time.Sleep(getSleepTime(attempt, 20*time.Millisecond))
 
 	if attempt >= n.maxRetries {
-		return ErrAttemptsExceededLimit{err}
+		return graph.ErrAttemptsExceededLimit{err}
 	}
 
 	return nil

--- a/neo4j/observation.go
+++ b/neo4j/observation.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 
 	"github.com/ONSdigital/dp-graph/observation"
+	"github.com/ONSdigital/dp-observation-importer/models"
 	"github.com/ONSdigital/go-ns/log"
+	"github.com/pkg/errors"
 )
 
 // StreamCSVRows returns a reader allowing individual CSV rows to be read.
@@ -72,4 +74,105 @@ func createOptionList(name string, opts []string) string {
 	}
 
 	return fmt.Sprintf("(%s)", strings.Join(q, " OR "))
+}
+
+func (n *Neo4j) InsertObservationBatch(ctx context.Context, attempt int, instanceID string, observations []*models.Observation, dimensionIDs map[string]string) error {
+	query := buildInsertObservationQuery(instanceID, observations)
+	if len(query) == 0 {
+		return errors.New("failed to create query for batch")
+	}
+
+	queryParameters, err := createParams(observations, dimensionIDs)
+	if err != nil {
+		return errors.Wrap(err, "failed to create query parameters for batch query")
+	}
+
+	queryResult, err := n.Exec(query, queryParameters)
+	if err != nil {
+		if neoErr := n.checkAttempts(err, instanceID, attempt); neoErr != nil {
+			return errors.Wrap(err, "observation batch save failed")
+		}
+
+		log.Info("got an error when saving observations, attempting to retry", log.Data{
+			"instance_id":  instanceID,
+			"retry_number": attempt,
+			"max_attempts": n.maxRetries,
+		})
+
+		return n.InsertObservationBatch(ctx, attempt+1, instanceID, observations, dimensionIDs)
+	}
+
+	rowsAffected, err := queryResult.RowsAffected()
+	if err != nil {
+		return errors.Wrap(err, "error attempting to get number of rows affected in query result")
+	}
+
+	log.Info("successfully saved observation batch", log.Data{"rows_affected": rowsAffected, "instance_id": instanceID})
+	return nil
+}
+
+// createParams creates parameters to inject into an insert query for each observation.
+func createParams(observations []*models.Observation, dimensionIDs map[string]string) (map[string]interface{}, error) {
+
+	rows := make([]interface{}, 0)
+
+	for _, observation := range observations {
+
+		row := map[string]interface{}{
+			"v": observation.Row,
+			"i": observation.RowIndex,
+		}
+
+		for _, option := range observation.DimensionOptions {
+
+			dimensionName := strings.ToLower(option.DimensionName)
+
+			dimensionLookUp := observation.InstanceID + "_" + dimensionName + "_" + option.Name
+
+			nodeID, ok := dimensionIDs[dimensionLookUp]
+			if !ok {
+				return nil, fmt.Errorf("No nodeId found for %s", dimensionLookUp)
+			}
+
+			row[dimensionName] = nodeID
+		}
+
+		rows = append(rows, row)
+	}
+
+	return map[string]interface{}{"rows": rows}, nil
+}
+
+// buildInsertObservationQuery creates an instance specific insert query.
+func buildInsertObservationQuery(instanceID string, observations []*models.Observation) string {
+	if len(instanceID) == 0 || len(observations) == 0 {
+		return ""
+	}
+
+	query := "UNWIND $rows AS row"
+
+	match := " MATCH "
+	where := " WHERE "
+	create := fmt.Sprintf(" CREATE (o:`_%s_observation` { value:row.v, rowIndex:row.i }), ", instanceID)
+
+	index := 0
+
+	for _, option := range observations[0].DimensionOptions {
+
+		if index != 0 {
+			match += ", "
+			where += " AND "
+			create += ", "
+		}
+		optionName := strings.ToLower(option.DimensionName)
+
+		match += fmt.Sprintf("(`%s`:`_%s_%s`)", optionName, instanceID, optionName)
+		where += fmt.Sprintf("id(`%s`) = toInt(row.`%s`)", optionName, optionName)
+		create += fmt.Sprintf("(o)-[:isValueOf]->(`%s`)", optionName)
+		index++
+	}
+
+	query += match + where + create
+
+	return query
 }

--- a/neo4j/observation_test.go
+++ b/neo4j/observation_test.go
@@ -2,13 +2,18 @@ package neo4j
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
+	graph "github.com/ONSdigital/dp-graph/graph/driver"
 	"github.com/ONSdigital/dp-graph/neo4j/driver"
 	"github.com/ONSdigital/dp-graph/neo4j/internal"
 	"github.com/ONSdigital/dp-graph/observation"
+	"github.com/ONSdigital/dp-observation-importer/models"
 	bolt "github.com/ONSdigital/golang-neo4j-bolt-driver"
+	neoErrors "github.com/ONSdigital/golang-neo4j-bolt-driver/errors"
+	"github.com/ONSdigital/golang-neo4j-bolt-driver/structures/messages"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -20,7 +25,7 @@ var mockConnNoErr = &internal.BoltConnMock{
 	CloseFunc: closeNoErr,
 }
 
-func TestStore_StreamCSVRows(t *testing.T) {
+func Test_StreamCSVRows(t *testing.T) {
 
 	Convey("Given an store with a mock DB connection", t, func() {
 
@@ -98,7 +103,7 @@ func TestStore_StreamCSVRows(t *testing.T) {
 	})
 }
 
-func TestStore_StreamCSVRowsEmptyFilter(t *testing.T) {
+func Test_StreamCSVRowsEmptyFilter(t *testing.T) {
 	filterID := "1234567890"
 	InstanceID := "0987654321"
 
@@ -171,7 +176,7 @@ func TestStore_StreamCSVRowsEmptyFilter(t *testing.T) {
 	})
 }
 
-func TestStore_StreamCSVRowsDimensionEmpty(t *testing.T) {
+func Test_StreamCSVRowsDimensionEmpty(t *testing.T) {
 
 	Convey("Given an store with a mock DB connection", t, func() {
 
@@ -224,6 +229,435 @@ func TestStore_StreamCSVRowsDimensionEmpty(t *testing.T) {
 			Convey("There is a row reader returned for the rows given by the database.", func() {
 				So(err, ShouldBeNil)
 				So(rowReader, ShouldNotBeNil)
+			})
+		})
+	})
+}
+
+var validObservation = &models.Observation{
+	InstanceID: "123",
+	Row:        "the,row,content",
+	RowIndex:   5678,
+	DimensionOptions: []*models.DimensionOption{
+		{DimensionName: "sex", Name: "Male"},
+		{DimensionName: "age", Name: "45"},
+	},
+}
+
+var uncachedObservation = &models.Observation{
+	InstanceID: "234",
+	Row:        "the,row,content",
+	RowIndex:   456,
+	DimensionOptions: []*models.DimensionOption{
+		{DimensionName: "sex", Name: "Male"},
+		{DimensionName: "age", Name: "45"},
+	},
+}
+
+var ids = map[string]string{
+	"123_sex_Male": "333",
+	"123_age_45":   "666",
+}
+
+func Test_InsertObservationBatch(t *testing.T) {
+	attempt := 1
+	instanceID := "123"
+
+	expectedQuery := "UNWIND $rows AS row" +
+		" MATCH (`sex`:`_123_sex`), (`age`:`_123_age`)" +
+		" WHERE id(`sex`) = toInt(row.`sex`) AND id(`age`) = toInt(row.`age`)" +
+		" CREATE (o:`_123_observation` { value:row.v, rowIndex:row.i }), (o)-[:isValueOf]->(`sex`), (o)-[:isValueOf]->(`age`)"
+
+	expectedParams := make(map[string]interface{})
+	rows := make([]interface{}, 0)
+	rows = append(rows, map[string]interface{}{
+		"v":   "the,row,content",
+		"i":   int64(5678),
+		"sex": "333",
+		"age": "666",
+	},
+		map[string]interface{}{
+			"v":   "the,row,content",
+			"i":   int64(5678),
+			"sex": "333",
+			"age": "666",
+		},
+		map[string]interface{}{
+			"v":   "the,row,content",
+			"i":   int64(5678),
+			"sex": "333",
+			"age": "666",
+		},
+	)
+
+	expectedParams["rows"] = rows
+
+	obs := []*models.Observation{validObservation, validObservation, validObservation}
+
+	Convey("Given a valid database connection and observations that exist in the dimenson map", t, func() {
+
+		res := &internal.ResultMock{
+			RowsAffectedFunc: func() (int64, error) {
+				return 1, nil
+			},
+		}
+
+		driver := &internal.Neo4jDriverMock{
+			ExecFunc: func(q string, params map[string]interface{}) (bolt.Result, error) {
+				return res, nil
+			},
+		}
+
+		db := &Neo4j{driver, 5, 30}
+
+		Convey("When InsertObservationBatch is called", func() {
+			err := db.InsertObservationBatch(context.Background(), attempt, instanceID, obs, ids)
+
+			Convey("Then no error should be returned", func() {
+				So(err, ShouldBeNil)
+				So(len(driver.ExecCalls()), ShouldEqual, 1)
+				So(driver.ExecCalls()[0].Query, ShouldEqual, expectedQuery)
+				So(driver.ExecCalls()[0].Params, ShouldResemble, expectedParams)
+			})
+		})
+	})
+
+	Convey("Given a valid database connection but an empty observation list", t, func() {
+		res := &internal.ResultMock{
+			RowsAffectedFunc: func() (int64, error) {
+				return 1, nil
+			},
+		}
+
+		driver := &internal.Neo4jDriverMock{
+			ExecFunc: func(q string, params map[string]interface{}) (bolt.Result, error) {
+				return res, nil
+			},
+		}
+
+		db := &Neo4j{driver, 5, 30}
+		empty := []*models.Observation{}
+
+		Convey("When InsertObservationBatch is called", func() {
+			err := db.InsertObservationBatch(context.Background(), attempt, instanceID, empty, ids)
+
+			Convey("Then an error should be returned and the database should not be called", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "failed to create query for batch")
+				So(len(driver.ExecCalls()), ShouldEqual, 0)
+			})
+		})
+	})
+
+	Convey("Given a valid database connection but an empty dimenson map", t, func() {
+
+		res := &internal.ResultMock{
+			RowsAffectedFunc: func() (int64, error) {
+				return 1, nil
+			},
+		}
+
+		driver := &internal.Neo4jDriverMock{
+			ExecFunc: func(q string, params map[string]interface{}) (bolt.Result, error) {
+				return res, nil
+			},
+		}
+
+		db := &Neo4j{driver, 5, 30}
+
+		Convey("When InsertObservationBatch is called", func() {
+			err := db.InsertObservationBatch(context.Background(), attempt, instanceID, obs, make(map[string]string))
+
+			Convey("Then an error should be returned and the database should not be called", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "failed to create query parameters for batch query")
+				So(len(driver.ExecCalls()), ShouldEqual, 0)
+			})
+		})
+	})
+
+	Convey("Given a flakey database connection and valid parameters", t, func() {
+		res := &internal.ResultMock{
+			RowsAffectedFunc: func() (int64, error) {
+				return 1, nil
+			},
+		}
+
+		count := 0
+		driver := &internal.Neo4jDriverMock{
+			ExecFunc: func(q string, params map[string]interface{}) (bolt.Result, error) {
+				if count == 0 {
+					count++
+					msg := make(map[string]interface{})
+					msg["code"] = "Neo.TransientError.Network.CommunicationError"
+					return nil, neoErrors.Wrap(messages.NewFailureMessage(msg), "transient error")
+				}
+				count++
+				return res, nil
+			},
+		}
+
+		db := &Neo4j{driver, 5, 30}
+
+		Convey("When InsertObservationBatch is called", func() {
+			err := db.InsertObservationBatch(context.Background(), attempt, instanceID, obs, ids)
+
+			Convey("Then no error should be returned but the database should be called twice", func() {
+				So(err, ShouldBeNil)
+				So(len(driver.ExecCalls()), ShouldEqual, 2)
+				So(driver.ExecCalls()[0].Query, ShouldEqual, expectedQuery)
+				So(driver.ExecCalls()[0].Params, ShouldResemble, expectedParams)
+			})
+		})
+	})
+
+	Convey("Given a malformed results but valid parameters", t, func() {
+		res := &internal.ResultMock{
+			RowsAffectedFunc: func() (int64, error) {
+				return 0, errors.New("something went wrong")
+			},
+		}
+
+		driver := &internal.Neo4jDriverMock{
+			ExecFunc: func(q string, params map[string]interface{}) (bolt.Result, error) {
+				return res, nil
+			},
+		}
+
+		db := &Neo4j{driver, 5, 30}
+
+		Convey("When InsertObservationBatch is called", func() {
+			err := db.InsertObservationBatch(context.Background(), attempt, instanceID, obs, ids)
+
+			Convey("Then an error should be returned and the database should only be called once", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "error attempting to get number of rows affected in query result")
+				So(err.Error(), ShouldContainSubstring, "something went wrong")
+				So(len(driver.ExecCalls()), ShouldEqual, 1)
+				So(driver.ExecCalls()[0].Query, ShouldEqual, expectedQuery)
+				So(driver.ExecCalls()[0].Params, ShouldResemble, expectedParams)
+				So(len(res.RowsAffectedCalls()), ShouldEqual, 1)
+			})
+		})
+	})
+
+	Convey("Given a complete failure in database connection but valid parameters", t, func() {
+		driver := &internal.Neo4jDriverMock{
+			ExecFunc: func(q string, params map[string]interface{}) (bolt.Result, error) {
+				return nil, graph.ErrNonRetriable{errors.New("non retriable")}
+			},
+		}
+
+		db := &Neo4j{driver, 5, 30}
+
+		Convey("When InsertObservationBatch is called", func() {
+			err := db.InsertObservationBatch(context.Background(), attempt, instanceID, obs, ids)
+
+			Convey("Then no error should be returned but the database should be called twice", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "observation batch save failed")
+				So(err.Error(), ShouldContainSubstring, "non retriable")
+				So(len(driver.ExecCalls()), ShouldEqual, 1)
+			})
+		})
+	})
+
+}
+
+func Test_createParams(t *testing.T) {
+
+	Convey("Given a populated dimension cache and a single valid observation", t, func() {
+		Convey("When create params is called with observations that exist in the cache", func() {
+			results, err := createParams([]*models.Observation{validObservation}, ids)
+
+			Convey("Then the returned map should contain new rows", func() {
+				rows := make([]interface{}, 0)
+				rows = append(rows, map[string]interface{}{
+					"v":   "the,row,content",
+					"i":   int64(5678),
+					"sex": "333",
+					"age": "666",
+				})
+
+				So(err, ShouldBeNil)
+				So(results, ShouldNotBeNil)
+				So(results["rows"], ShouldResemble, rows)
+
+			})
+		})
+	})
+
+	Convey("Given a populated dimension cache and a list of 3 valid observations", t, func() {
+		obs := []*models.Observation{validObservation, validObservation, validObservation}
+
+		Convey("When create params is called with observations that exist in the cache", func() {
+			results, err := createParams(obs, ids)
+
+			Convey("Then the returned map should contain 3 new rows", func() {
+				rows := make([]interface{}, 0)
+				rows = append(rows, map[string]interface{}{
+					"v":   "the,row,content",
+					"i":   int64(5678),
+					"sex": "333",
+					"age": "666",
+				},
+					map[string]interface{}{
+						"v":   "the,row,content",
+						"i":   int64(5678),
+						"sex": "333",
+						"age": "666",
+					},
+					map[string]interface{}{
+						"v":   "the,row,content",
+						"i":   int64(5678),
+						"sex": "333",
+						"age": "666",
+					})
+
+				So(err, ShouldBeNil)
+				So(results, ShouldNotBeNil)
+				So(results["rows"], ShouldResemble, rows)
+
+			})
+		})
+	})
+
+	Convey("Given a populated dimension cache and a list containing an uncached observation", t, func() {
+		obs := []*models.Observation{validObservation, uncachedObservation, validObservation}
+
+		Convey("When create params is called and observations cant be found in the cache", func() {
+			results, err := createParams(obs, ids)
+
+			Convey("Then the returned map should be empty and an error returned", func() {
+				So(err, ShouldNotBeNil)
+				So(err, ShouldResemble, errors.New("No nodeId found for 234_sex_Male"))
+				So(results, ShouldBeNil)
+			})
+		})
+	})
+
+	Convey("Given an empty dimension cache and a list of valid observations", t, func() {
+		obs := []*models.Observation{validObservation, validObservation, validObservation}
+
+		Convey("When create params is called and observations cant be found in the cache", func() {
+			results, err := createParams(obs, make(map[string]string))
+
+			Convey("Then the returned map should be empty and an error returned", func() {
+				So(err, ShouldNotBeNil)
+				So(err, ShouldResemble, errors.New("No nodeId found for 123_sex_Male"))
+				So(results, ShouldBeNil)
+			})
+		})
+	})
+
+	Convey("Given a populated dimension cache and no observations", t, func() {
+		Convey("When create params is called and no observations exist", func() {
+			results, err := createParams([]*models.Observation{}, ids)
+
+			Convey("Then the returned map should not contain new rows", func() {
+				So(err, ShouldBeNil)
+				So(results, ShouldNotBeNil)
+				So(results["rows"], ShouldBeEmpty)
+			})
+		})
+	})
+
+}
+
+func Test_buildInsertObservationQuery(t *testing.T) {
+	Convey("Given an instance ID and observations for one dimension", t, func() {
+		id := "123"
+		obs := []*models.Observation{
+			&models.Observation{
+				InstanceID: "123",
+				DimensionOptions: []*models.DimensionOption{
+					&models.DimensionOption{
+						DimensionName: "age",
+					},
+				},
+			},
+		}
+
+		Convey("When buildInsertObservationQuery is called", func() {
+			r := buildInsertObservationQuery(id, obs)
+
+			Convey("Then a valid query string is returned", func() {
+				So(r, ShouldNotBeEmpty)
+				So(r, ShouldEqual, "UNWIND $rows AS row MATCH (`age`:`_123_age`) WHERE id(`age`) = toInt(row.`age`) CREATE (o:`_123_observation` { value:row.v, rowIndex:row.i }), (o)-[:isValueOf]->(`age`)")
+			})
+		})
+	})
+
+	Convey("Given an instance ID and observations for two dimensions", t, func() {
+		id := "123"
+		obs := []*models.Observation{
+			&models.Observation{
+				InstanceID: "123",
+				DimensionOptions: []*models.DimensionOption{
+					&models.DimensionOption{
+						DimensionName: "age",
+					},
+					&models.DimensionOption{
+						DimensionName: "time",
+					},
+				},
+			},
+		}
+
+		Convey("When buildInsertObservationQuery is called", func() {
+			r := buildInsertObservationQuery(id, obs)
+
+			Convey("Then a valid query string is returned", func() {
+				So(r, ShouldNotBeEmpty)
+				So(r, ShouldEqual, "UNWIND $rows AS row MATCH (`age`:`_123_age`), (`time`:`_123_time`) WHERE id(`age`) = toInt(row.`age`) AND id(`time`) = toInt(row.`time`) CREATE (o:`_123_observation` { value:row.v, rowIndex:row.i }), (o)-[:isValueOf]->(`age`), (o)-[:isValueOf]->(`time`)")
+			})
+		})
+	})
+
+	Convey("Given no instance ID and a valid list of observations", t, func() {
+		id := ""
+		obs := []*models.Observation{
+			&models.Observation{
+				InstanceID: "123",
+				DimensionOptions: []*models.DimensionOption{
+					&models.DimensionOption{
+						DimensionName: "age",
+					},
+				},
+			},
+		}
+
+		Convey("When buildInsertObservationQuery is called", func() {
+			r := buildInsertObservationQuery(id, obs)
+
+			Convey("Then an empty string is returned", func() {
+				So(r, ShouldBeEmpty)
+			})
+		})
+	})
+
+	Convey("Given an instance ID but no observations", t, func() {
+		id := "123"
+		obs := []*models.Observation{}
+
+		Convey("When buildInsertObservationQuery is called", func() {
+			r := buildInsertObservationQuery(id, obs)
+
+			Convey("Then an empty string is returned", func() {
+				So(r, ShouldBeEmpty)
+			})
+		})
+	})
+
+	Convey("Given no instance ID or observations", t, func() {
+		id := "123"
+		obs := []*models.Observation{}
+
+		Convey("When buildInsertObservationQuery is called", func() {
+			r := buildInsertObservationQuery(id, obs)
+
+			Convey("Then an empty string is returned", func() {
+				So(r, ShouldBeEmpty)
 			})
 		})
 	})


### PR DESCRIPTION
### What

add InsertObservationBatch function to observation interface and neo4j impementation so the observation importer can use the abstraction

move the errors to the generic package so they can be more easily reused

### How to review

check changes make sense and work when implemented: https://github.com/ONSdigital/dp-observation-importer/pull/51

### Who can review

anyone