### PR TITLE
Fix neo4j hierarchy reads to return results with no children

### DIFF
--- a/neo4j/driver/driver.go
+++ b/neo4j/driver/driver.go
@@ -11,6 +11,9 @@ import (
 )
 
 //go:generate moq -out ../internal/driver.go -pkg internal . Neo4jDriver
+//go:generate moq -out ../internal/bolt.go -pkg internal . Result
+
+type Result bolt.Result
 
 type Neo4jDriver interface {
 	Read(query string, mapp mapper.ResultMapper, single bool) error

--- a/neo4j/hierarchy_reader.go
+++ b/neo4j/hierarchy_reader.go
@@ -4,15 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ONSdigital/dp-graph/graph/driver"
 	"github.com/ONSdigital/dp-graph/neo4j/mapper"
 	"github.com/ONSdigital/dp-graph/neo4j/query"
 	"github.com/ONSdigital/dp-hierarchy-api/models"
 	"github.com/ONSdigital/go-ns/log"
-	bolt "github.com/ONSdigital/golang-neo4j-bolt-driver"
 )
-
-//go:generate moq -out internal/bolt.go -pkg internal . Result
-type Result bolt.Result
 
 type neoArgMap map[string]interface{}
 
@@ -54,20 +51,22 @@ func (n *Neo4j) GetHierarchyElement(ctx context.Context, instanceID, dimension, 
 }
 
 // QueryResponse performs DB query (neoStmt, neoArgs) returning Response (should be singular)
-func (n *Neo4j) queryResponse(instanceID, dimension string, neoStmt string, neoArgs neoArgMap) (res *models.Response, err error) {
-	logData := log.Data{"statement": neoStmt, "row_count": 0, "neo_args": neoArgs}
+func (n *Neo4j) queryResponse(instanceID, dimension string, neoStmt string, neoArgs neoArgMap) (*models.Response, error) {
+	logData := log.Data{"statement": neoStmt, "neo_args": neoArgs}
 	log.Trace("QueryResponse executing get query", logData)
 
-	res = &models.Response{}
+	res := &models.Response{}
+	var err error
+
 	if err = n.ReadWithParams(neoStmt, neoArgs, mapper.Hierarchy(res), false); err != nil {
 		return nil, err
 	}
 
-	if res.Children, err = n.getChildren(instanceID, dimension, res.ID); err != nil {
-		return
+	if res.Children, err = n.getChildren(instanceID, dimension, res.ID); err != nil && err != driver.ErrNotFound {
+		return nil, err
 	}
 
-	return
+	return res, nil
 }
 
 func (n *Neo4j) getChildren(instanceID, dimension, code string) ([]*models.Element, error) {


### PR DESCRIPTION
### What

make sure that when getChildren returns no results, the containing response is still returned so elements without children still work in the hierarchy

### How to review

check works here: https://github.com/ONSdigital/dp-hierarchy-api/pull/30
check tests pass

### Who can review

anyone