### PR TITLE
Update timeout env var name to be more descriptive

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A library to abstract graph database logic away from services
 | GRAPH_ADDR           |   ""    |  address of the database matching the chosen driver type
 | GRAPH_POOL_SIZE      |   0     |  desired size of the connection pool
 | MAX_RETRIES          |   0     |  maximum number of attempts for transient query failures
-| QUERY_TIMEOUT        |   0     |  maximum number of seconds to allow a query before timing out
+| GRAPH_QUERY_TIMEOUT  |   0     |  maximum number of seconds to allow a query before timing out
 
 All config other than `GRAPH_DRIVER_TYPE` will be subject to that implementation to make use of
 and set reasonable defaults for use in that context. It's feasible that some implementations

--- a/config/config.go
+++ b/config/config.go
@@ -16,7 +16,7 @@ type Configuration struct {
 	DatabaseAddress string `envconfig:"GRAPH_ADDR"`
 	PoolSize        int    `envconfig:"GRAPH_POOL_SIZE"`
 	MaxRetries      int    `envconfig:"MAX_RETRIES"`
-	QueryTimeout    int    `envconfig:"QUERY_TIMEOUT"`
+	QueryTimeout    int    `envconfig:"GRAPH_QUERY_TIMEOUT"`
 
 	Driver driver.Driver
 }


### PR DESCRIPTION
### What

Update config for timeout env var name because the config was wrong in production, which suggests to me the naming was not sufficiently clear

### How to review

sanity check

### Who can review

anyone