### PR TITLE
Feature/neptune pete

### DIFF
--- a/DESIGN-NOTES.md
+++ b/DESIGN-NOTES.md
@@ -1,0 +1,64 @@
+# Design Notes
+
+The code in the dp-graph repository provides a generalised interface to 
+diverse graph databases - for a particular set of business application 
+use-cases. This document explains something of the code organisation, its 
+approach to the separation of concerns, and composition.
+
+> Nb. I reverse engineered this document from the code (Pete) - so don't assume it is completely correct.
+
+One such business application use-case is formed from the requirements that 
+the **CodeList** API service has for a graph database. We'll use this as
+an example.
+
+## API
+
+The library API is defined by the graph and graph.driver packages.
+
+The **graph** package provides the **DB** type (a struct) - which is the
+object clients interact with. Clients interested in the Code List use-case
+can construct a DB specialised to this case with graph.NewCodeListStore().
+Other use-cases are catered for; like NewHierarchyStore().
+
+The API contract offered by NewCodeListStore() is defined by the 
+graph.driver.CodeList interface. For example GetCodeList().
+
+## Composition and Configuration
+
+The database variant to be employed is determined at runtime by the 
+**config** package from an environment variable setting. 
+
+If for example the database variant is specified as "neptune", the database
+is constructed using neptune.New() and the returned object used as the 
+**driver** in the graph.DB structure providing the external API. 
+
+The graph.DB's **driver** attribute type is only required to implement the 
+(ultra minimal) graph.driver.Driver interface. 
+
+However in our example use-case it must also satisfy the 
+graph.driver.CodeList interface. The config package therefore checks that the
+driver returned by neptune.New() also satisfies the CodeList interface as 
+well - using a type assertion.
+
+Note that graph.DB uses Go's embedded fields. For example the graph.DB struct 
+contains an embedded driver.CodeList. It being "embedded" means that the
+methods of CodeList can be accessed either through the implicit attribute 
+name "CodeList", **or** the shortcut form of a **promoted** method like 
+this: DB.GetCodeList().
+
+Note also the way the config package sets all the DB attributes typified by
+DB.Codelist, either to nil or to the (typecast) config.Driver attribute.
+Which suggests these attributes differ, but they not! If the database variant
+in use supports say the CodeList interface and the Hierarchy inteface, and
+both of these are selected, then both the CodeList attribute and the Hierarchy 
+attribute will be set - but with the same Neptune driver object.
+
+## Diverse Database Implementations
+
+The dp-graph repo contains both Neptune and Neo4J directories, providing
+their own graph.driver implementation as well as their CodeList (and family)
+implementations. Typically these exploit an external low-level database driver.
+For example gedge/gremlin-neptune. They then typically provide a convenience 
+library containing methods like getVertices() that uses the lower level 
+driver, and makes it simpler to satisfy the methods for CodeList etc.
+

--- a/DESIGN-NOTES.md
+++ b/DESIGN-NOTES.md
@@ -5,7 +5,8 @@ diverse graph databases - for a particular set of business application
 use-cases. This document explains something of the code organisation, its 
 approach to the separation of concerns, and composition.
 
-> Nb. I reverse engineered this document from the code (Pete) - so don't assume it is completely correct.
+> Nb. I reverse engineered this document from the code (Pete) - so 
+don't assume it is completely correct.
 
 One such business application use-case is formed from the requirements that 
 the **CodeList** API service has for a graph database. We'll use this as

--- a/DESIGN-NOTES.md
+++ b/DESIGN-NOTES.md
@@ -18,11 +18,21 @@ The library API is defined by the graph and graph.driver packages.
 
 The **graph** package provides the **DB** type (a struct) - which is the
 object clients interact with. Clients interested in the Code List use-case
-can construct a DB specialised to this case with graph.NewCodeListStore().
-Other use-cases are catered for; like NewHierarchyStore().
+can construct a DB specialised to this case with `graph.NewCodeListStore()`
 
-The API contract offered by NewCodeListStore() is defined by the 
-graph.driver.CodeList interface. For example GetCodeList().
+Other use-cases are catered for; like `NewHierarchyStore()`.
+
+The API contract offered by `NewCodeListStore()` is defined by the 
+`graph.driver.CodeList` interface. For example `GetCodeList()`.
+
+## Diverse Database Implementations
+
+The dp-graph repo contains both Neptune and Neo4J directories, providing
+their own `graph.driver` implementation as well as their `CodeList` (and family)
+implementations. Typically these exploit an external low-level database driver.
+For example `gedge/gremlin-neptune`. They then typically provide a convenience 
+library containing methods like `getVertices()` that uses the lower level 
+driver, and makes it simpler to satisfy the methods for `CodeList` etc.
 
 ## Composition and Configuration
 
@@ -30,36 +40,26 @@ The database variant to be employed is determined at runtime by the
 **config** package from an environment variable setting. 
 
 If for example the database variant is specified as "neptune", the database
-is constructed using neptune.New() and the returned object used as the 
-**driver** in the graph.DB structure providing the external API. 
+is constructed using `neptune.New()` and the returned object used as the 
+**driver** in the `graph.DB` structure providing the external API. 
 
-The graph.DB's **driver** attribute type is only required to implement the 
-(ultra minimal) graph.driver.Driver interface. 
+The `graph.DB`'s `driver` attribute type is only required to implement the 
+(ultra minimal) `graph.driver.Driver` interface. 
 
 However in our example use-case it must also satisfy the 
-graph.driver.CodeList interface. The config package therefore checks that the
-driver returned by neptune.New() also satisfies the CodeList interface as 
+`graph.driver.CodeList` interface. The `config` package therefore checks that the
+driver returned by `neptune.New()` also satisfies the `CodeList` interface as 
 well - using a type assertion.
 
-Note that graph.DB uses Go's embedded fields. For example the graph.DB struct 
-contains an embedded driver.CodeList. It being "embedded" means that the
+Note that `graph.DB` uses Go's embedded fields. For example the `graph.DB` struct 
+contains an embedded `driver.CodeList`. It being "embedded" means that the
 methods of CodeList can be accessed either through the implicit attribute 
-name "CodeList", **or** the shortcut form of a **promoted** method like 
-this: DB.GetCodeList().
+name `CodeList`, **or** the shortcut form of a **promoted** method like 
+this: `DB.GetCodeList()`.
 
 Note also the way the config package sets all the DB attributes typified by
-DB.Codelist, either to nil or to the (typecast) config.Driver attribute.
-Which suggests these attributes differ, but they not! If the database variant
-in use supports say the CodeList interface and the Hierarchy inteface, and
-both of these are selected, then both the CodeList attribute and the Hierarchy 
-attribute will be set - but with the same Neptune driver object.
-
-## Diverse Database Implementations
-
-The dp-graph repo contains both Neptune and Neo4J directories, providing
-their own graph.driver implementation as well as their CodeList (and family)
-implementations. Typically these exploit an external low-level database driver.
-For example gedge/gremlin-neptune. They then typically provide a convenience 
-library containing methods like getVertices() that uses the lower level 
-driver, and makes it simpler to satisfy the methods for CodeList etc.
-
+`DB.Codelist`, either to nil or to the (typecast) `config.Driver attribute`.
+Which suggests these attributes differ, _but they do not_! If the database variant
+in use supports say the `CodeList` interface and the `Hierarchy` inteface, and
+both of these are selected, then both the `CodeList` attribute and the 
+`Hierarchy` attribute will be set - but with the same Neptune driver object.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ and set reasonable defaults for use in that context. It's feasible that some imp
 might not have configurable timeouts for example, so whether this can be set should be
 documented in each driver.
 
+### Design
+
+See [DESIGN](DESIGN-NOTES.md) for details.
+
 ### Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md) for details.

--- a/neptune/codelists.go
+++ b/neptune/codelists.go
@@ -45,7 +45,9 @@ func (n *NeptuneDB) GetCodeLists(ctx context.Context, filterBy string) (*models.
 
 // GetCodeList provides a CodeList for a given ID, having checked it exists
 // in the database. Nb. The caller is expected to fully qualify the embedded
-// Links field afterwards.
+// Links field afterwards. It returns an error if:
+// - The Gremlin query failed to execute.
+// - The requested CodeList does not exist.
 func (n *NeptuneDB) GetCodeList(ctx context.Context, codeListID string) (
 	*models.CodeList, error) {
 	existsQry := fmt.Sprintf(query.CodeListExists, codeListID)

--- a/neptune/codelists.go
+++ b/neptune/codelists.go
@@ -47,7 +47,7 @@ func (n *NeptuneDB) GetCodeLists(ctx context.Context, filterBy string) (*models.
 // in the database. Nb. The caller is expected to fully qualify the embedded
 // Links field afterwards. It returns an error if:
 // - The Gremlin query failed to execute.
-// - The requested CodeList does not exist.
+// - The requested CodeList does not exist. (error is `ErrNotFound`)
 func (n *NeptuneDB) GetCodeList(ctx context.Context, codeListID string) (
 	*models.CodeList, error) {
 	existsQry := fmt.Sprintf(query.CodeListExists, codeListID)

--- a/neptune/driver/driver.go
+++ b/neptune/driver/driver.go
@@ -7,7 +7,7 @@ import (
 )
 
 type NeptuneDriver struct {
-	Pool *gremgo.Pool
+	Pool NeptunePool // Defined with an interface to support mocking.
 }
 
 func New(ctx context.Context, dbAddr string, errs chan error) (*NeptuneDriver, error) {

--- a/neptune/driver/neptunepool.go
+++ b/neptune/driver/neptunepool.go
@@ -1,0 +1,26 @@
+package driver
+
+import (
+	gremgo "github.com/gedge/gremgo-neptune"
+)
+
+/*
+Interface NeptunePool defines the contract required of the gremgo 
+connection Pool by the Neptune.Driver.
+*/
+type NeptunePool interface {
+
+    Close()
+
+    Execute(query string, bindings, rebindings map[string]string) (
+        resp []gremgo.Response, err error)
+
+    Get(query string, bindings, rebindings map[string]string) (
+        resp interface{}, err error)
+
+    GetCount(q string, bindings, rebindings map[string]string) (
+        i int64, err error)
+
+    GetE(q string, bindings, rebindings map[string]string) (
+        resp interface{}, err error)
+}

--- a/neptune/driver/neptunepool.go
+++ b/neptune/driver/neptunepool.go
@@ -12,15 +12,8 @@ type NeptunePool interface {
 
     Close()
 
-    Execute(query string, bindings, rebindings map[string]string) (
-        resp []gremgo.Response, err error)
-
-    Get(query string, bindings, rebindings map[string]string) (
-        resp interface{}, err error)
-
-    GetCount(q string, bindings, rebindings map[string]string) (
-        i int64, err error)
-
-    GetE(q string, bindings, rebindings map[string]string) (
-        resp interface{}, err error)
+    Execute(query string, bindings, rebindings map[string]string) (resp []gremgo.Response, err error)
+    Get(query string, bindings, rebindings map[string]string) (resp interface{}, err error)
+    GetCount(q string, bindings, rebindings map[string]string) (i int64, err error)
+    GetE(q string, bindings, rebindings map[string]string) (resp interface{}, err error)
 }


### PR DESCRIPTION
### What

- Update the hard-coded response from neptune.GetCodeList to use a real database query.
- As the first illustrative use-case of upgrading the remainder of the CodeList implementation.
- Change the gremgo.Pool field in the neptune.driver.NeptuneDriver from being a struct type, to being
an interface.
- So that it is ready to be mocked for unit tests coming soon.

### How to review

Run this vendored version of dp-graph against the hierarchy builder and make sure nothing has been broken.

### Who can review

Describe who worked on the changes, so that other people can review = Pete H
