### PR TITLE
Feature/neptune geteditions

### DIFF
--- a/neptune/codelists.go
+++ b/neptune/codelists.go
@@ -33,7 +33,7 @@ func (n *NeptuneDB) GetCodeLists(ctx context.Context, filterBy string) (*models.
 	}
 	results := &models.CodeListResults{
 		Count:      len(codeListVertices),
-		Limit:      -1,
+		Limit:      len(codeListVertices),
 		TotalCount: len(codeListVertices),
 	}
 	for _, codeListVertex := range codeListVertices {
@@ -80,10 +80,11 @@ func (n *NeptuneDB) GetCodeList(ctx context.Context, codeListID string) (
 
 /*
 GetEditions provides a models.Editions structure populated based on the
-the values in the Code List vertices in the database, that have the provided 
+the values in the Code List vertices in the database, that have the provided
 codeListId.
 It returns an error if:
 - The Gremlin query failed to execute. (wrapped error)
+- No CodeLists are found of the requested codeListID (error is ErrNotFound')
 - A CodeList is found that does not have the "edition" property (error is 'ErrNoSuchProperty')
 */
 func (n *NeptuneDB) GetEditions(ctx context.Context, codeListID string) (*models.Editions, error) {
@@ -92,10 +93,13 @@ func (n *NeptuneDB) GetEditions(ctx context.Context, codeListID string) (*models
 	if err != nil {
 		return nil, errors.Wrapf(err, "Gremlin query failed: %q", qry)
 	}
+	if len(codeLists) == 0 {
+		return nil, driver.ErrNotFound
+	}
 	editions := &models.Editions{
 		Count:      len(codeLists),
 		Offset:     0,
-		Limit:      -1,
+		Limit:      len(codeLists),
 		TotalCount: len(codeLists),
 		Items:      []models.Edition{},
 	}

--- a/neptune/codelists_test.go
+++ b/neptune/codelists_test.go
@@ -243,6 +243,17 @@ func TestGetEditions(t *testing.T) {
 			})
 		})
 	})
+	Convey("Given a database that returns zero edition vertices", t, func() {
+		poolMock := &internal.NeptunePoolMock{GetFunc: internal.ReturnZeroVertices}
+		db := mockDB(poolMock)
+		Convey("When GetEditions() is called", func() {
+			unusedCodeListID := "unused-id"
+			_, err := db.GetEditions(context.Background(), unusedCodeListID)
+			Convey("Then the returned error should be ErrNotFound", func() {
+				So(err, ShouldEqual, driver.ErrNotFound)
+			})
+		})
+	})
 	Convey("Given a database that returns three edition vertices", t, func() {
 		poolMock := &internal.NeptunePoolMock{GetFunc: internal.ReturnThreeEditionVertices}
 		db := mockDB(poolMock)

--- a/neptune/internal/mockpoolutils.go
+++ b/neptune/internal/mockpoolutils.go
@@ -61,6 +61,20 @@ var ReturnThreeCodeLists = func(query string, bindings map[string]string, rebind
 	return codeLists, nil
 }
 
+// ReturnThreeEditionVertices is mock implementation for NeptunePool.Get() that always
+// returns a slice of three graphson.Vertex(s):
+// - of type "unused-vertex-type"
+// - with a an "edition" property set to "edition_0", "edition_1", and "edition_2" respectively.
+var ReturnThreeEditionVertices = func(query string, bindings map[string]string, rebindings map[string]string) (interface{}, error) {
+	editions := []graphson.Vertex{}
+	for i := 0; i < 3; i++ {
+		vertex := makeVertex("unused-vertex-type")
+		setVertexStringProperty(&vertex, "edition", fmt.Sprintf("edition_%d", i))
+		editions = append(editions, vertex)
+	}
+	return editions, nil
+}
+
 // ReturnThreeUselessVertices is mock implementation for NeptunePool.Get() that always
 // returns a slice of three graphson.Vertex(s) of type "_useless_vertex_type", and with
 // no properties set.

--- a/neptune/query/query.go
+++ b/neptune/query/query.go
@@ -2,15 +2,15 @@ package query
 
 const (
 	// codelists
-	GetCodeLists         = "g.V().hasLabel('_code_list')"
-	GetCodeListsFiltered = "g.V().hasLabel('_code_list').has('%s', 'true')"
-	GetCodeList          = "g.V().hasLabel('_code_list').has('listID', '%s')"
-	CodeListExists       = "g.V().hasLabel('_code_list').has('listID', '%s').count()"
-	CodeListEditionExists   = "g.V().hasLabel('_code_list').has('listID', '%s').has('edition', '%s').count()"
-	CountEditions        = "g.V().hasLabel('_code_list').hasLabel('_code_list_%s').has('edition','%s').count()"
-	GetCodes             = "g.V().hasLabel('_code').as('c').out('usedBy').as('r').inV().hasLabel('_code_list').hasLabel('_code_list_%s').has('edition','%s').select('c','r')"
-	GetCode              = "g.V().hasLabel('_code').has('value','%s').as('c').out('usedBy').as('r').inV().hasLabel('_code_list').hasLabel('_code_list_%s').has('edition','%s').select('c','r')"
-	GetCodeDatasets      = "g.V().hasLabel('_code_list').hasLabel('_code_list_%s').has('edition','%s').inE('usedBy').as('r').match(" +
+	GetCodeLists          = "g.V().hasLabel('_code_list')"
+	GetCodeListsFiltered  = "g.V().hasLabel('_code_list').has('%s', 'true')"
+	GetCodeList           = "g.V().hasLabel('_code_list').has('listID', '%s')"
+	CodeListExists        = "g.V().hasLabel('_code_list').has('listID', '%s').count()"
+	CodeListEditionExists = "g.V().hasLabel('_code_list').has('listID', '%s').has('edition', '%s').count()"
+	CodeListEditions      = "g.V().hasLabel('_code_list').has('listID', '%s').values('edition')"
+	GetCodes              = "g.V().hasLabel('_code').as('c').out('usedBy').as('r').inV().hasLabel('_code_list').hasLabel('_code_list_%s').has('edition','%s').select('c','r')"
+	GetCode               = "g.V().hasLabel('_code').has('value','%s').as('c').out('usedBy').as('r').inV().hasLabel('_code_list').hasLabel('_code_list_%s').has('edition','%s').select('c','r')"
+	GetCodeDatasets       = "g.V().hasLabel('_code_list').hasLabel('_code_list_%s').has('edition','%s').inE('usedBy').as('r').match(" +
 		"__.as('r').outV().has('value','%s').as('c')," +
 		"__.as('c').out('inDataset').as('d')," +
 		"__.as('d').has('is_published',true)" +

--- a/neptune/query/query.go
+++ b/neptune/query/query.go
@@ -7,7 +7,6 @@ const (
 	GetCodeList           = "g.V().hasLabel('_code_list').has('listID', '%s')"
 	CodeListExists        = "g.V().hasLabel('_code_list').has('listID', '%s').count()"
 	CodeListEditionExists = "g.V().hasLabel('_code_list').has('listID', '%s').has('edition', '%s').count()"
-	CodeListEditions      = "g.V().hasLabel('_code_list').has('listID', '%s').values('edition')"
 	GetCodes              = "g.V().hasLabel('_code').as('c').out('usedBy').as('r').inV().hasLabel('_code_list').hasLabel('_code_list_%s').has('edition','%s').select('c','r')"
 	GetCode               = "g.V().hasLabel('_code').has('value','%s').as('c').out('usedBy').as('r').inV().hasLabel('_code_list').hasLabel('_code_list_%s').has('edition','%s').select('c','r')"
 	GetCodeDatasets       = "g.V().hasLabel('_code_list').hasLabel('_code_list_%s').has('edition','%s').inE('usedBy').as('r').match(" +


### PR DESCRIPTION
### What

Provided a real implementation of `codelists.GetEditions()` that queries the database.

### How to review

In addition to the usual code scrutiny, please:
1) run the tests in `codelists_test.go`.
2) exercise the code from a running CodeList API service configured to use Neptune, by requesting this end point:

`http://localhost:22400/code-lists/ashe-earnings/editions`

The expected results are:

`
    "items": [
        {
            "edition": "",
            "label": "",
            "links": {
                "self": {
                    "id": "one-off",
                    "href": "http://localhost:22400/code-lists/ashe-earnings/editions/one-off"
                },
                "editions": {
                    "href": "http://localhost:22400/code-lists/ashe-earnings/editions"
                },
                "codes": {
                    "href": "http://localhost:22400/code-lists/ashe-earnings/editions/one-off/codes"
                }
            }
        }
    ],
    "count": 1,
    "offset": 0,
    "limit": 1,
    "total_count": 1
`
 
### Who can review

Describe who worked on the changes (Pete), so that other people can review. (Eleanor)
