### PR TITLE
Adapt code to use <bool> rather than <"bool"> Code List **type** fields

### DIFF
--- a/neptune/codelists.go
+++ b/neptune/codelists.go
@@ -14,7 +14,7 @@ import (
 /*
 GetCodeLists provides a list of either all Code Lists, or a list of only those
 having a boolean property with the name <filterBy> which is set to true. E.g.
-"geography": "true". The caller is expected to
+"geography": true. The caller is expected to
 fully qualify the embedded Links field afterwards. It returns an error if:
 - The Gremlin query failed to execute.
 - A CodeList is encountered that does not have *listID* property.

--- a/neptune/codelists_test.go
+++ b/neptune/codelists_test.go
@@ -50,7 +50,7 @@ func TestGetCodeLists(t *testing.T) {
 				calls := poolMock.GetCalls()
 				So(len(calls), ShouldEqual, 1)
 				Convey("With a different (more-qualified) query string", func() {
-					expectedQry := `g.V().hasLabel('_code_list').has('listID_2', 'true')`
+					expectedQry := `g.V().hasLabel('_code_list').has('listID_2', true)`
 					actualQry := calls[0].Query
 					So(actualQry, ShouldEqual, expectedQry)
 				})
@@ -67,7 +67,7 @@ func TestGetCodeLists(t *testing.T) {
 			filterBy := "unusedFilter"
 			_, err := db.GetCodeLists(context.Background(), filterBy)
 			expectedErr := `Gremlin query failed: "g.V().hasLabel('_code_list'` +
-				`).has('unusedFilter', 'true')":  MALFORMED REQUEST `
+				`).has('unusedFilter', true)":  MALFORMED REQUEST `
 			Convey("Then the returned error should wrap the underlying one", func() {
 				So(err.Error(), ShouldEqual, expectedErr)
 			})

--- a/neptune/query/query.go
+++ b/neptune/query/query.go
@@ -3,7 +3,7 @@ package query
 const (
 	// codelists
 	GetCodeLists          = "g.V().hasLabel('_code_list')"
-	GetCodeListsFiltered  = "g.V().hasLabel('_code_list').has('%s', 'true')"
+	GetCodeListsFiltered  = "g.V().hasLabel('_code_list').has('%s', true)"
 	GetCodeList           = "g.V().hasLabel('_code_list').has('listID', '%s')"
 	CodeListExists        = "g.V().hasLabel('_code_list').has('listID', '%s').count()"
 	CodeListEditionExists = "g.V().hasLabel('_code_list').has('listID', '%s').has('edition', '%s').count()"


### PR DESCRIPTION
To synch with the corresponding change the data loading scripts.


### How to review

In addition to the usual code scrutiny, please:
1) run the tests in neptune/codelists
2) check that the response from the (Neptune) Code List API service at `http://localhost:22400/code-lists?type=geography` returns a self link referring to `code-lists/ashe-geography`

### Who can review

Describe who worked on the changes (Pete), so that other people can review. (Eleanor)
