### PR TITLE
Provide proper implementation of codelists/GetCode

### DIFF
--- a/neptune/codelists.go
+++ b/neptune/codelists.go
@@ -193,6 +193,17 @@ func (n *NeptuneDB) GetCodes(ctx context.Context, codeListID, edition string) (*
 }
 
 func (n *NeptuneDB) GetCode(ctx context.Context, codeListID, edition string, code string) (*models.Code, error) {
+	qry := fmt.Sprintf(query.CodeExists, codeListID, edition, code)
+	nFound, err := n.getNumber(qry)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Gremlin query failed: %q", qry)
+	}
+	if nFound == 0 {
+		return nil, driver.ErrNotFound
+	}
+	if nFound > 1 {
+		return nil, driver.ErrMultipleFound
+	}
 	return &models.Code{
 		Links: &models.CodeLinks{
 			Self: &models.Link{

--- a/neptune/query/query.go
+++ b/neptune/query/query.go
@@ -7,9 +7,13 @@ const (
 	GetCodeList           = "g.V().hasLabel('_code_list').has('listID', '%s')"
 	CodeListExists        = "g.V().hasLabel('_code_list').has('listID', '%s').count()"
 	CodeListEditionExists = "g.V().hasLabel('_code_list').has('listID', '%s').has('edition', '%s').count()"
-	GetCodes              = "g.V().hasLabel('_code_list').has('listID', '%s').has('edition', '%s').in('usedBy').hasLabel('_code')"
-	GetCode               = "g.V().hasLabel('_code').has('value','%s').as('c').out('usedBy').as('r').inV().hasLabel('_code_list').hasLabel('_code_list_%s').has('edition','%s').select('c','r')"
-	GetCodeDatasets       = "g.V().hasLabel('_code_list').hasLabel('_code_list_%s').has('edition','%s').inE('usedBy').as('r').match(" +
+	GetCodes              = "g.V().hasLabel('_code_list')" +
+		".has('listID', '%s').has('edition', '%s')" +
+		".in('usedBy').hasLabel('_code')"
+	CodeExists = "g.V().hasLabel('_code_list')" +
+		".has('listID', '%s').has('edition', '%s')" +
+		".in('usedBy').has('value', '%s').count()"
+	GetCodeDatasets = "g.V().hasLabel('_code_list').hasLabel('_code_list_%s').has('edition','%s').inE('usedBy').as('r').match(" +
 		"__.as('r').outV().has('value','%s').as('c')," +
 		"__.as('c').out('inDataset').as('d')," +
 		"__.as('d').has('is_published',true)" +


### PR DESCRIPTION
### How to review

In addition to the usual code scrutiny, please:

1) run the tests in codelists_test.go.
2) exercise the code from a running CodeList API service configured to use Neptune, by requesting this end point:

`http://localhost:22400/code-lists/ashe-earnings/editions/one-off/codes/hourly-pay-gross`

The response should include a self link with the same URL as above.

With the `hourly-pay-gross' changed to 'hourly-pay-gros' the response should be 404: "not found"

### Who can review

Describe who worked on the changes (Pete), so that other people can review.
