### PR TITLE
Switch to ONSdigital forks of gremgo-neptune and graphson

### DIFF
--- a/neptune/driver/driver.go
+++ b/neptune/driver/driver.go
@@ -3,7 +3,7 @@ package driver
 import (
 	"context"
 
-	gremgo "github.com/gedge/gremgo-neptune"
+	gremgo "github.com/ONSdigital/gremgo-neptune"
 )
 
 type NeptuneDriver struct {

--- a/neptune/driver/neptunepool.go
+++ b/neptune/driver/neptunepool.go
@@ -1,7 +1,8 @@
 package driver
 
 import (
-	gremgo "github.com/gedge/gremgo-neptune"
+	"github.com/ONSdigital/graphson"
+	gremgo "github.com/ONSdigital/gremgo-neptune"
 )
 
 //go:generate moq -out ../internal/pool.go -pkg internal . NeptunePool
@@ -13,7 +14,7 @@ connection Pool by the Neptune.Driver.
 type NeptunePool interface {
 	Close()
 	Execute(query string, bindings, rebindings map[string]string) (resp []gremgo.Response, err error)
-	Get(query string, bindings, rebindings map[string]string) (resp interface{}, err error)
+	Get(query string, bindings, rebindings map[string]string) ([]graphson.Vertex, error)
 	GetCount(q string, bindings, rebindings map[string]string) (i int64, err error)
 	GetE(q string, bindings, rebindings map[string]string) (resp interface{}, err error)
 	GetStringList(query string, bindings, rebindings map[string]string) (vals []string, err error)

--- a/neptune/hierarchy.go
+++ b/neptune/hierarchy.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ONSdigital/dp-graph/neptune/query"
 	"github.com/ONSdigital/dp-hierarchy-api/models"
 	"github.com/ONSdigital/go-ns/log"
-	"github.com/gedge/graphson"
+	"github.com/ONSdigital/graphson"
 )
 
 func (n *NeptuneDB) CreateInstanceHierarchyConstraints(ctx context.Context, attempt int, instanceID, dimensionName string) error {

--- a/neptune/internal/mockpoolutils.go
+++ b/neptune/internal/mockpoolutils.go
@@ -3,7 +3,7 @@ package internal
 import (
 	"fmt"
 
-	"github.com/gedge/graphson"
+	"github.com/ONSdigital/graphson"
 )
 
 /*
@@ -41,9 +41,9 @@ var ReturnMalformedIntRequestErr = func(q string, bindings, rebindings map[strin
 }
 
 // ReturnMalformedNilInterfaceRequestErr is a mock implementation for
-// NeptunePool functions that return  (Interface{}, error) which always returns an
+// NeptunePool functions that return  ([]graphson.Vertex, error) which always returns an
 // error that is judged to be not transient by neptune.isTransientError
-var ReturnMalformedNilInterfaceRequestErr = func(q string, bindings, rebindings map[string]string) (interface{}, error) {
+var ReturnMalformedNilInterfaceRequestErr = func(q string, bindings, rebindings map[string]string) ([]graphson.Vertex, error) {
 	return nil, errors.New(" MALFORMED REQUEST ")
 }
 
@@ -59,7 +59,7 @@ var ReturnMalformedStringListRequestErr = func(q string, bindings, rebindings ma
 // - of type "_code_list"
 // - with a "listID" property set to "listID_0", "listID_1", and "ListID_2" respectively.
 // - with an "edition" property set to "my-test-edition"
-var ReturnThreeCodeLists = func(query string, bindings map[string]string, rebindings map[string]string) (interface{}, error) {
+var ReturnThreeCodeLists = func(query string, bindings map[string]string, rebindings map[string]string) ([]graphson.Vertex, error) {
 	codeLists := []graphson.Vertex{}
 	for i := 0; i < 3; i++ {
 		vertex := makeCodeListVertex(i, "my-test-edition")
@@ -72,7 +72,7 @@ var ReturnThreeCodeLists = func(query string, bindings map[string]string, rebind
 // returns a slice of three graphson.Vertex(s):
 // - of type "unused-vertex-type"
 // - with a an "edition" property set to "edition_0", "edition_1", and "edition_2" respectively.
-var ReturnThreeEditionVertices = func(query string, bindings map[string]string, rebindings map[string]string) (interface{}, error) {
+var ReturnThreeEditionVertices = func(query string, bindings map[string]string, rebindings map[string]string) ([]graphson.Vertex, error) {
 	editions := []graphson.Vertex{}
 	for i := 0; i < 3; i++ {
 		vertex := makeVertex("unused-vertex-type")
@@ -86,7 +86,7 @@ var ReturnThreeEditionVertices = func(query string, bindings map[string]string, 
 // returns a slice of three graphson.Vertex(s):
 // - of type "unused-vertex-type"
 // - with a "value" property set to "code_0", "code_1", and "code_2" respectively.
-var ReturnThreeCodeVertices = func(query string, bindings map[string]string, rebindings map[string]string) (interface{}, error) {
+var ReturnThreeCodeVertices = func(query string, bindings map[string]string, rebindings map[string]string) ([]graphson.Vertex, error) {
 	codes := []graphson.Vertex{}
 	for i := 0; i < 3; i++ {
 		vertex := makeVertex("unused-vertex-type")
@@ -99,7 +99,7 @@ var ReturnThreeCodeVertices = func(query string, bindings map[string]string, reb
 // ReturnThreeUselessVertices is mock implementation for NeptunePool.Get() that always
 // returns a slice of three graphson.Vertex(s) of type "_useless_vertex_type", and with
 // no properties set.
-var ReturnThreeUselessVertices = func(query string, bindings map[string]string, rebindings map[string]string) (interface{}, error) {
+var ReturnThreeUselessVertices = func(query string, bindings map[string]string, rebindings map[string]string) ([]graphson.Vertex, error) {
 	codeLists := []graphson.Vertex{}
 	for i := 0; i < 3; i++ {
 		vertex := makeVertex("_useless_vertex_type")
@@ -109,7 +109,7 @@ var ReturnThreeUselessVertices = func(query string, bindings map[string]string, 
 }
 
 // ReturnZeroVertices provides an empty list of graphson.Vertex(s)
-var ReturnZeroVertices = func(query string, bindings map[string]string, rebindings map[string]string) (interface{}, error) {
+var ReturnZeroVertices = func(query string, bindings map[string]string, rebindings map[string]string) ([]graphson.Vertex, error) {
 	return []graphson.Vertex{}, nil
 }
 

--- a/neptune/internal/pool.go
+++ b/neptune/internal/pool.go
@@ -5,7 +5,8 @@ package internal
 
 import (
 	"github.com/ONSdigital/dp-graph/neptune/driver"
-	"github.com/gedge/gremgo-neptune"
+	"github.com/ONSdigital/graphson"
+	"github.com/ONSdigital/gremgo-neptune"
 	"sync"
 )
 
@@ -34,7 +35,7 @@ var _ driver.NeptunePool = &NeptunePoolMock{}
 //             ExecuteFunc: func(query string, bindings map[string]string, rebindings map[string]string) ([]gremgo.Response, error) {
 // 	               panic("mock out the Execute method")
 //             },
-//             GetFunc: func(query string, bindings map[string]string, rebindings map[string]string) (interface{}, error) {
+//             GetFunc: func(query string, bindings map[string]string, rebindings map[string]string) ([]graphson.Vertex, error) {
 // 	               panic("mock out the Get method")
 //             },
 //             GetCountFunc: func(q string, bindings map[string]string, rebindings map[string]string) (int64, error) {
@@ -60,7 +61,7 @@ type NeptunePoolMock struct {
 	ExecuteFunc func(query string, bindings map[string]string, rebindings map[string]string) ([]gremgo.Response, error)
 
 	// GetFunc mocks the Get method.
-	GetFunc func(query string, bindings map[string]string, rebindings map[string]string) (interface{}, error)
+	GetFunc func(query string, bindings map[string]string, rebindings map[string]string) ([]graphson.Vertex, error)
 
 	// GetCountFunc mocks the GetCount method.
 	GetCountFunc func(q string, bindings map[string]string, rebindings map[string]string) (int64, error)
@@ -190,7 +191,7 @@ func (mock *NeptunePoolMock) ExecuteCalls() []struct {
 }
 
 // Get calls GetFunc.
-func (mock *NeptunePoolMock) Get(query string, bindings map[string]string, rebindings map[string]string) (interface{}, error) {
+func (mock *NeptunePoolMock) Get(query string, bindings map[string]string, rebindings map[string]string) ([]graphson.Vertex, error) {
 	if mock.GetFunc == nil {
 		panic("NeptunePoolMock.GetFunc: method is nil but NeptunePool.Get was just called")
 	}

--- a/neptune/mapper.go
+++ b/neptune/mapper.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ONSdigital/dp-graph/neptune/query"
 	"github.com/ONSdigital/dp-hierarchy-api/models"
 	"github.com/ONSdigital/go-ns/log"
-	"github.com/gedge/graphson"
+	"github.com/ONSdigital/graphson"
 )
 
 func (n *NeptuneDB) convertVertexToResponse(v graphson.Vertex, instanceID, dimension string) (res *models.Response, err error) {

--- a/neptune/neptune.go
+++ b/neptune/neptune.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/ONSdigital/dp-graph/neptune/driver"
 	"github.com/ONSdigital/go-ns/log"
-	"github.com/gedge/graphson"
+	"github.com/ONSdigital/graphson"
 )
 
 type NeptuneDB struct {


### PR DESCRIPTION
Also required changes to some mocking furniture because a a gremgo pool
method signature had been changed.

### What

Imported the new ONSdigital versions of gremgo and graphson, in favour of the (now deprecated) gedge respositories. Required repairing subsequently failing tests due to a new method signature in gremgo.

### How to review

This is mostly a boiler plate change. So all that is needed is to make sure the unit tests pass, after the go generate step in neptune/driver has been run afresh to produce a new gremgo pool mock type.

### Who can review

Describe who worked on the changes, so that other people can review.
