### PR TITLE
Feature/neptune hierarchy

### DIFF
--- a/neptune/hierarchy.go
+++ b/neptune/hierarchy.go
@@ -32,7 +32,7 @@ func (n *NeptuneDB) CloneNodes(ctx context.Context, attempt int, instanceID, cod
 	log.Debug("cloning nodes from the generic hierarchy", logData)
 
 	if _, err = n.getVertices(gremStmt); err != nil {
-		log.ErrorC("get", err, logData)
+		log.ErrorC("cannot get vertices during cloning", err, logData)
 		return
 	}
 
@@ -50,7 +50,7 @@ func (n *NeptuneDB) CountNodes(ctx context.Context, instanceID, dimensionName st
 	log.Debug("counting nodes in the new instance hierarchy", logData)
 
 	if count, err = n.getNumber(gremStmt); err != nil {
-		log.ErrorC("getNumber", err, logData)
+		log.ErrorC("cannot count nodes in a hierarchy", err, logData)
 		return
 	}
 	return
@@ -75,7 +75,7 @@ func (n *NeptuneDB) CloneRelationships(ctx context.Context, attempt int, instanc
 	log.Debug("cloning relationships from the generic hierarchy", logData)
 
 	if _, err = n.getEdges(gremStmt); err != nil {
-		log.ErrorC("getEdges", err, logData)
+		log.ErrorC("cannot find edges while cloning relationships", err, logData)
 		return
 	}
 
@@ -97,7 +97,7 @@ func (n *NeptuneDB) RemoveCloneEdges(ctx context.Context, attempt int, instanceI
 	log.Debug("removing edges to generic hierarchy", logData)
 
 	if _, err = n.exec(gremStmt); err != nil {
-		log.ErrorC("exec", err, logData)
+		log.ErrorC("exec failed while removing edges during removal of unwanted cloned edges", err, logData)
 		return
 	}
 	return
@@ -120,7 +120,7 @@ func (n *NeptuneDB) SetNumberOfChildren(ctx context.Context, attempt int, instan
 	log.Debug("setting number-of-children property value on the instance hierarchy nodes", logData)
 
 	if _, err = n.getVertices(gremStmt); err != nil {
-		log.ErrorC("getV", err, logData)
+		log.ErrorC("cannot find vertices while settting nChildren on hierarhy nodes", err, logData)
 		return
 	}
 
@@ -145,7 +145,7 @@ func (n *NeptuneDB) SetHasData(ctx context.Context, attempt int, instanceID, dim
 	log.Debug("setting has-data property on the instance hierarchy", logData)
 
 	if _, err = n.getVertices(gremStmt); err != nil {
-		log.ErrorC("getV", err, logData)
+		log.ErrorC("cannot find vertices while setting hasData on hierarchy nodes", err, logData)
 		return
 	}
 
@@ -169,7 +169,7 @@ func (n *NeptuneDB) MarkNodesToRemain(ctx context.Context, attempt int, instance
 	log.Debug("marking nodes to remain after trimming sparse branches", logData)
 
 	if _, err = n.getVertices(gremStmt); err != nil {
-		log.ErrorC("getV", err, logData)
+		log.ErrorC("cannot find vertices while marking hierarchy nodes to keep", err, logData)
 		return
 	}
 
@@ -187,7 +187,7 @@ func (n *NeptuneDB) RemoveNodesNotMarkedToRemain(ctx context.Context, attempt in
 	log.Debug("removing nodes not marked to remain after trimming sparse branches", logData)
 
 	if _, err = n.exec(gremStmt); err != nil {
-		log.ErrorC("exec", err, logData)
+		log.ErrorC("exec query failed while removing hierarchy nodes to cull", err, logData)
 		return
 	}
 	return
@@ -204,7 +204,7 @@ func (n *NeptuneDB) RemoveRemainMarker(ctx context.Context, attempt int, instanc
 	log.Debug("removing the remain property from the nodes that remain", logData)
 
 	if _, err = n.exec(gremStmt); err != nil {
-		log.ErrorC("exec", err, logData)
+		log.ErrorC("exec query failed while removing spent remain markers from hierarchy nodes", err, logData)
 		return
 	}
 	return
@@ -221,11 +221,11 @@ func (n *NeptuneDB) GetHierarchyCodelist(ctx context.Context, instanceID, dimens
 
 	var vertex graphson.Vertex
 	if vertex, err = n.getVertex(gremStmt); err != nil {
-		log.ErrorC("get", err, logData)
+		log.ErrorC("cannot get vertices  while searching for code list node related to hierarchy node", err, logData)
 		return
 	}
 	if codelistID, err = vertex.GetProperty("code_list"); err != nil {
-		log.ErrorC("bad prop", err, logData)
+		log.ErrorC("cannot read code_list property from node", err, logData)
 		return
 	}
 	return
@@ -242,26 +242,27 @@ func (n *NeptuneDB) GetHierarchyRoot(ctx context.Context, instanceID, dimension 
 
 	var vertices []graphson.Vertex
 	if vertices, err = n.getVertices(gremStmt); err != nil {
-		log.ErrorC("get", err, logData)
+		log.ErrorC("getVertices failed: cannot find hierarchy root node candidates ", err, logData)
 		return
 	}
 	if len(vertices) == 0 {
 		err = driver.ErrNotFound
-		log.ErrorC("get", err, logData)
+		log.ErrorC("Cannot find hierarchy root node", err, logData)
 		return
 	}
 	if len(vertices) > 1 {
 		err = driver.ErrMultipleFound
-		log.ErrorC("get", err, logData)
+		log.ErrorC("Cannot identify hierarchy root node because are multiple candidates", err, logData)
 		return
 	}
 	var vertex graphson.Vertex
 	vertex = vertices[0]
-	// Note the call to convertVertexToResponse below does much more than meets the eye,
+	// Note the call to buildHierarchyNodeFromGraphsonVertex below does much more than meets the eye,
 	// including launching new queries in of itself to fetch child nodes, and
 	// breadcrumb nodes.
-	if node, err = n.convertVertexToResponse(vertex, instanceID, dimension); err != nil {
-		log.ErrorC("conv", err, logData)
+	wantBreadcrumbs := false // Because meaningless for a root node
+	if node, err = n.buildHierarchyNodeFromGraphsonVertex(vertex, instanceID, dimension, wantBreadcrumbs); err != nil {
+		log.ErrorC("Cannot extract related information needed from hierarchy node", err, logData)
 		return
 	}
 	return
@@ -279,14 +280,15 @@ func (n *NeptuneDB) GetHierarchyElement(ctx context.Context, instanceID, dimensi
 
 	var vertex graphson.Vertex
 	if vertex, err = n.getVertex(gremStmt); err != nil {
-		log.ErrorC("get", err, logData)
+		log.ErrorC("Cannot find vertex when looking for specific hierarchy node", err, logData)
 		return
 	}
-	// Note the call to convertVertexToResponse below does much more than meets the eye,
+	// Note the call to buildHierarchyNodeFromGraphsonVertex below does much more than meets the eye,
 	// including launching new queries in of itself to fetch child nodes, and
 	// breadcrumb nodes.
-	if node, err = n.convertVertexToResponse(vertex, instanceID, dimension); err != nil {
-		log.ErrorC("conv", err, logData)
+	wantBreadcrumbs := true // Because we are at depth in the hierarchy
+	if node, err = n.buildHierarchyNodeFromGraphsonVertex(vertex, instanceID, dimension, wantBreadcrumbs); err != nil {
+		log.ErrorC("Cannot extract related information needed from hierarchy node", err, logData)
 		return
 	}
 	return

--- a/neptune/hierarchy.go
+++ b/neptune/hierarchy.go
@@ -120,7 +120,7 @@ func (n *NeptuneDB) SetNumberOfChildren(ctx context.Context, attempt int, instan
 	log.Debug("setting number-of-children property value on the instance hierarchy nodes", logData)
 
 	if _, err = n.getVertices(gremStmt); err != nil {
-		log.ErrorC("cannot find vertices while settting nChildren on hierarhy nodes", err, logData)
+		log.ErrorC("cannot find vertices while settting nChildren on hierarchy nodes", err, logData)
 		return
 	}
 

--- a/neptune/hierarchy.go
+++ b/neptune/hierarchy.go
@@ -257,6 +257,9 @@ func (n *NeptuneDB) GetHierarchyRoot(ctx context.Context, instanceID, dimension 
 	}
 	var vertex graphson.Vertex
 	vertex = vertices[0]
+	// Note the call to convertVertexToResponse below does much more than meets the eye,
+	// including launching new queries in of itself to fetch child nodes, and
+	// breadcrumb nodes.
 	if node, err = n.convertVertexToResponse(vertex, instanceID, dimension); err != nil {
 		log.ErrorC("conv", err, logData)
 		return
@@ -279,6 +282,9 @@ func (n *NeptuneDB) GetHierarchyElement(ctx context.Context, instanceID, dimensi
 		log.ErrorC("get", err, logData)
 		return
 	}
+	// Note the call to convertVertexToResponse below does much more than meets the eye,
+	// including launching new queries in of itself to fetch child nodes, and
+	// breadcrumb nodes.
 	if node, err = n.convertVertexToResponse(vertex, instanceID, dimension); err != nil {
 		log.ErrorC("conv", err, logData)
 		return

--- a/neptune/hierarchy.go
+++ b/neptune/hierarchy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ONSdigital/dp-graph/graph/driver"
 	"github.com/ONSdigital/dp-graph/neptune/query"
 	"github.com/ONSdigital/dp-hierarchy-api/models"
 	"github.com/ONSdigital/go-ns/log"
@@ -239,11 +240,23 @@ func (n *NeptuneDB) GetHierarchyRoot(ctx context.Context, instanceID, dimension 
 		"dimension_name": dimension,
 	}
 
-	var vertex graphson.Vertex
-	if vertex, err = n.getVertex(gremStmt); err != nil {
+	var vertices []graphson.Vertex
+	if vertices, err = n.getVertices(gremStmt); err != nil {
 		log.ErrorC("get", err, logData)
 		return
 	}
+	if len(vertices) == 0 {
+		err = driver.ErrNotFound
+		log.ErrorC("get", err, logData)
+		return
+	}
+	if len(vertices) > 1 {
+		err = driver.ErrMultipleFound
+		log.ErrorC("get", err, logData)
+		return
+	}
+	var vertex graphson.Vertex
+	vertex = vertices[0]
 	if node, err = n.convertVertexToResponse(vertex, instanceID, dimension); err != nil {
 		log.ErrorC("conv", err, logData)
 		return

--- a/neptune/mapper.go
+++ b/neptune/mapper.go
@@ -13,8 +13,8 @@ import (
 	"github.com/ONSdigital/graphson"
 )
 
-func (n *NeptuneDB) convertVertexToResponse(v graphson.Vertex, instanceID, dimension string) (res *models.Response, err error) {
-	logData := log.Data{"fn": "convertVertexToResponse"}
+func (n *NeptuneDB) buildHierarchyNodeFromGraphsonVertex(v graphson.Vertex, instanceID, dimension string, wantBreadcrumbs bool) (res *models.Response, err error) {
+	logData := log.Data{"fn": "buildHierarchyNodeFromGraphsonVertex"}
 
 	res = &models.Response{}
 	// Note we are using the vertex' *code* property for the response model's
@@ -69,7 +69,7 @@ func (n *NeptuneDB) convertVertexToResponse(v graphson.Vertex, instanceID, dimen
 		}
 	}
 	// Fetch new data from the database concerned with the node's breadcrumbs.
-	if res.HasData {
+	if wantBreadcrumbs {
 		res.Breadcrumbs, err = n.buildBreadcrumbs(instanceID, dimension, res.ID)
 		if err != nil {
 			log.ErrorC("building breadcrumbs", err, logData)

--- a/neptune/mapper.go
+++ b/neptune/mapper.go
@@ -1,5 +1,9 @@
 package neptune
 
+/*
+This module is dedicated to the needs of the hierarchy API.
+*/
+
 import (
 	"fmt"
 
@@ -13,6 +17,9 @@ func (n *NeptuneDB) convertVertexToResponse(v graphson.Vertex, instanceID, dimen
 	logData := log.Data{"fn": "convertVertexToResponse"}
 
 	res = &models.Response{}
+	// Note we are using the vertex' *code* property for the response model's
+	// ID field - because in the case of a hierarchy node, this is the ID
+	// used to format links.
 	if res.ID, err = v.GetProperty("code"); err != nil {
 		log.ErrorC("bad GetProp code", err, logData)
 		return
@@ -30,6 +37,7 @@ func (n *NeptuneDB) convertVertexToResponse(v graphson.Vertex, instanceID, dimen
 		log.ErrorC("bad hasData", err, logData)
 		return
 	}
+	// Fetch new data from the database concerned with the node's children.
 	if res.NoOfChildren > 0 && instanceID != "" {
 		var code string
 		if code, err = v.GetProperty("code"); err != nil {
@@ -60,13 +68,49 @@ func (n *NeptuneDB) convertVertexToResponse(v graphson.Vertex, instanceID, dimen
 			res.Children = append(res.Children, childElement)
 		}
 	}
+	// Fetch new data from the database concerned with the node's breadcrumbs.
+	if res.HasData {
+		res.Breadcrumbs, err = n.buildBreadcrumbs(instanceID, dimension, res.ID)
+		if err != nil {
+			log.ErrorC("building breadcrumbs", err, logData)
+		}
+	}
 	return
+}
+
+/*
+buildBreadcrumbs launches a new query to the database, to trace the (recursive)
+parentage of a hierarcy node. It converts the returned chain of parent
+graphson vertices into a chain of models.Element, and returns this list of
+elements.
+*/
+func (n *NeptuneDB) buildBreadcrumbs(instanceID, dimension, code string) ([]*models.Element, error) {
+	logData := log.Data{"fn": "buildBreadcrumbs"}
+	gremStmt := fmt.Sprintf(query.GetAncestry, instanceID, dimension, code)
+	logData["statement"] = gremStmt
+	ancestorVertices, err := n.getVertices(gremStmt)
+	if err != nil {
+		log.ErrorC("getVertices", err, logData)
+		return nil, err
+	}
+	elements := []*models.Element{}
+	for _, ancestor := range ancestorVertices {
+		element, err := convertVertexToElement(ancestor)
+		if err != nil {
+			log.ErrorC("convertVertexToElement", err, logData)
+			return nil, err
+		}
+		elements = append(elements, element)
+	}
+	return elements, nil
 }
 
 func convertVertexToElement(v graphson.Vertex) (res *models.Element, err error) {
 	logData := log.Data{"fn": "convertVertexToElement"}
-
 	res = &models.Element{}
+	// Note we are using the vertex' *code* property for the response model's
+	// ID field - because in the case of a hierarchy node, this is the ID
+	// used to format links.
 	if res.ID, err = v.GetProperty("code"); err != nil {
 		log.ErrorC("bad GetProp code", err, logData)
 		return

--- a/neptune/mapper.go
+++ b/neptune/mapper.go
@@ -12,9 +12,12 @@ import (
 func (n *NeptuneDB) convertVertexToResponse(v graphson.Vertex, instanceID, dimension string) (res *models.Response, err error) {
 	logData := log.Data{"fn": "convertVertexToResponse"}
 
-	res = &models.Response{
-		ID: v.GetID(),
+	res = &models.Response{}
+	if res.ID, err = v.GetProperty("code"); err != nil {
+		log.ErrorC("bad GetProp code", err, logData)
+		return
 	}
+
 	if res.Label, err = v.GetLabel(); err != nil {
 		log.ErrorC("bad label", err, logData)
 		return
@@ -63,8 +66,10 @@ func (n *NeptuneDB) convertVertexToResponse(v graphson.Vertex, instanceID, dimen
 func convertVertexToElement(v graphson.Vertex) (res *models.Element, err error) {
 	logData := log.Data{"fn": "convertVertexToElement"}
 
-	res = &models.Element{
-		ID: v.GetID(),
+	res = &models.Element{}
+	if res.ID, err = v.GetProperty("code"); err != nil {
+		log.ErrorC("bad GetProp code", err, logData)
+		return
 	}
 
 	if res.Label, err = v.GetLabel(); err != nil {

--- a/neptune/query/query.go
+++ b/neptune/query/query.go
@@ -71,7 +71,8 @@ const (
 	GetHierarchyRoot    = "g.V().hasLabel('_hierarchy_node_%s_%s').not(outE('hasParent'))"
 	GetHierarchyElement = "g.V().hasLabel('_hierarchy_node_%s_%s').has('code','%s')"
 	GetChildren         = "g.V().hasLabel('_hierarchy_node_%s_%s').has('code','%s').in('hasParent').order().by('label')"
-	GetAncestry         = "g.V().hasLabel('_hierarchy_node_%s_%s').has('code','%s').out('hasParent')"
+	// Note this query is recursive
+	GetAncestry = "g.V().hasLabel('_hierarchy_node_%s_%s').has('code', '%s').repeat(out('hasParent')).emit()"
 
 	// instance - import process
 	CreateInstance                   = "g.addV('_%s_Instance').property(single,'header','%s')"

--- a/neptune/query/query.go
+++ b/neptune/query/query.go
@@ -47,6 +47,7 @@ const (
 	CloneHierarchyNodes = "g.V().hasLabel('_generic_hierarchy_node_%s').as('old')" +
 		".addV('_hierarchy_node_%s_%s')" +
 		".property('code',select('old').values('code'))" +
+		".property('label',select('old').values('label'))" +
 		".property('code_list','%s').as('new')" +
 		".addE('clone_of').to('old').select('new')"
 	CountHierarchyNodes         = "g.V().hasLabel('_hierarchy_node_%s_%s').count()"

--- a/neptune/query/query.go
+++ b/neptune/query/query.go
@@ -48,6 +48,7 @@ const (
 		".addV('_hierarchy_node_%s_%s')" +
 		".property('code',select('old').values('code'))" +
 		".property('label',select('old').values('label'))" +
+		".property(single, 'hasData', false)" +
 		".property('code_list','%s').as('new')" +
 		".addE('clone_of').to('old').select('new')"
 	CountHierarchyNodes         = "g.V().hasLabel('_hierarchy_node_%s_%s').count()"
@@ -59,7 +60,7 @@ const (
 	SetNumberOfChildren = "g.V().hasLabel('_hierarchy_node_%s_%s').property(single,'numberOfChildren',__.in('hasParent').count())"
 	SetHasData          = "g.V().hasLabel('_hierarchy_node_%s_%s').as('v')" +
 		`.V().hasLabel('_%s_%s').as('c').where('v',eq('c')).by('code').by('value').` +
-		`select('v').property('hasData',true)`
+		`select('v').property(single, 'hasData',true)`
 	MarkNodesToRemain = "g.V().hasLabel('_hierarchy_node_%s_%s').has('hasData').property('remain',true)" +
 		".repeat(out('hasParent')).emit().property('remain',true)"
 	RemoveNodesNotMarkedToRemain = "g.V().hasLabel('_hierarchy_node_%s_%s').not(has('remain',true)).drop()"

--- a/neptune/query/query.go
+++ b/neptune/query/query.go
@@ -66,7 +66,7 @@ const (
 
 	// hierarchy read
 	HierarchyExists     = "g.V().hasLabel('_hierarchy_node_%s_%s').limit(1)"
-	GetHierarchyRoot    = "g.V().hasLabel('_hierarchy_node_%s_%s').not(outE('hasParent')).limit(1)"
+	GetHierarchyRoot    = "g.V().hasLabel('_hierarchy_node_%s_%s').not(outE('hasParent'))"
 	GetHierarchyElement = "g.V().hasLabel('_hierarchy_node_%s_%s').has('code','%s')"
 	GetChildren         = "g.V().hasLabel('_hierarchy_node_%s_%s').has('code','%s').in('hasParent').order().by('label')"
 	GetAncestry         = "g.V().hasLabel('_hierarchy_node_%s_%s').has('code','%s').out('hasParent')"


### PR DESCRIPTION
### What

Upgraded the existing (placeholder) code to do *read* operations on hierarchy data to a state that it works properly against live test data in Neptune, in the context of its only current consumer: the hiearchy API service.

### Why

So that the hierarchy api service becomes Neptune-ready. I.e. it will work when configured with the Neptune backend.

### How to review

In addition to code inspection, you can exercise it to inspect the returned payloads, by using the hierarchy api service configured to use Neptune. The current (transient) test data in Neptune facilitates this entry point URL for getting the root of hierarchy, which produces in turn, links that exercise the query for a specific node inside the query.

http://localhost:22600/hierarchies/INSTID/aggregate

A known node that **hasData** and is a couple of levels down in a hierarchy is this one (and thus exhibits breadcrumbs in the response) is:

http://localhost:22600/hierarchies/INSTID/aggregate/62.0

### Who can review

Describe who worked on the changes (Pete), so that other people can review (Eleanor)
