### PR TITLE
Fix neptune queries to be explicit on single cardinality and add docs

### DIFF
--- a/neptune/query/query.go
+++ b/neptune/query/query.go
@@ -1,5 +1,10 @@
 package query
 
+// Neptune implements a slight variance of Gremlin, so queries must be written with both specs in mind
+// (https://docs.aws.amazon.com/neptune/latest/userguide/access-graph-gremlin-differences.html)
+// Important practices:
+// 1) .property() function must contain 'single' where not a list, as the Neptune default is 'set'
+
 const (
 	// codelists
 	GetCodeLists          = "g.V().hasLabel('_code_list')"
@@ -46,9 +51,9 @@ const (
 	// hierarchy write
 	CloneHierarchyNodes = "g.V().hasLabel('_generic_hierarchy_node_%s').as('old')" +
 		".addV('_hierarchy_node_%s_%s')" +
-		".property('code',select('old').values('code'))" +
-		".property('label',select('old').values('label'))" +
-		".property(single, 'hasData', false)" +
+		".property(single,'code',select('old').values('code'))" +
+		".property(single,'label',select('old').values('label'))" +
+		".property(single,'hasData', false)" +
 		".property('code_list','%s').as('new')" +
 		".addE('clone_of').to('old').select('new')"
 	CountHierarchyNodes         = "g.V().hasLabel('_hierarchy_node_%s_%s').count()"
@@ -60,9 +65,9 @@ const (
 	SetNumberOfChildren = "g.V().hasLabel('_hierarchy_node_%s_%s').property(single,'numberOfChildren',__.in('hasParent').count())"
 	SetHasData          = "g.V().hasLabel('_hierarchy_node_%s_%s').as('v')" +
 		`.V().hasLabel('_%s_%s').as('c').where('v',eq('c')).by('code').by('value').` +
-		`select('v').property('hasData',true)`
-	MarkNodesToRemain = "g.V().hasLabel('_hierarchy_node_%s_%s').has('hasData').property('remain',true)" +
-		".repeat(out('hasParent')).emit().property('remain',true)"
+		`select('v').property(single,'hasData',true)`
+	MarkNodesToRemain = "g.V().hasLabel('_hierarchy_node_%s_%s').has('hasData').property(single,'remain',true)" +
+		".repeat(out('hasParent')).emit().property(single,'remain',true)"
 	RemoveNodesNotMarkedToRemain = "g.V().hasLabel('_hierarchy_node_%s_%s').not(has('remain',true)).drop()"
 	RemoveRemainMarker           = "g.V().hasLabel('_hierarchy_node_%s_%s').has('remain').properties('remain').drop()"
 


### PR DESCRIPTION
### What

Fix neptune queries to be explicit on single cardinality and add docs

### How to review

check every .property() call in the file contains 'single' or should logically be a list

### Who can review

anyone