### PR TITLE
Update codes query to also return labels

### DIFF
--- a/neptune/codelist.go
+++ b/neptune/codelist.go
@@ -166,7 +166,8 @@ func (n *NeptuneDB) GetCodes(ctx context.Context, codeListID, edition string) (*
 		return nil, driver.ErrNotFound
 	}
 
-	records, err := createRecords(values, 2)
+	const valuesPerRecord = 2
+	records, err := createRecords(values, valuesPerRecord)
 	if err != nil {
 		return nil, err
 	}
@@ -222,16 +223,16 @@ func (n *NeptuneDB) GetCode(ctx context.Context, codeListID, edition string, cod
 }
 
 // convert a flat array of record values into  a 2d array of records
-func createRecords(values []string, stride int) ([][]string, error) {
-	var records = [][]string{}
-	if len(values)%stride != 0 {
-		return nil, errors.New(fmt.Sprintf("List length is not divisible by %d", stride))
+func createRecords(values []string, valuesPerRecord int) ([][]string, error) {
+	var records [][]string
+	if len(values)%valuesPerRecord != 0 {
+		return nil, fmt.Errorf("list length is not divisible by %d", valuesPerRecord)
 	}
-	for i := 0; i < len(values); i += stride {
+	for i := 0; i < len(values); i += valuesPerRecord {
 
 		var record []string
 
-		for j := 0; j < stride; j++ {
+		for j := 0; j < valuesPerRecord; j++ {
 			value := values[i+j]
 			record = append(record, value)
 		}

--- a/neptune/codelists_test.go
+++ b/neptune/codelists_test.go
@@ -321,7 +321,7 @@ func TestGetCodes(t *testing.T) {
 			unusedCodeListID := "unused-id"
 			unusedEdition := "unused-edition"
 			_, err := db.GetCodes(context.Background(), unusedCodeListID, unusedEdition)
-			expectedErr := `List length is not divisible by 2`
+			expectedErr := `list length is not divisible by 2`
 			Convey("Then the returned error should wrap the underlying one", func() {
 				So(err.Error(), ShouldEqual, expectedErr)
 			})

--- a/neptune/codelists_test.go
+++ b/neptune/codelists_test.go
@@ -375,7 +375,7 @@ func TestGetCode(t *testing.T) {
 				So(len(calls), ShouldEqual, 1)
 				Convey("With a well formed query string", func() {
 					expectedQry := `g.V().hasLabel('_code_list').has('listID', 'unused-code-list').has('edition', ` +
-						`'unused-edition').in('usedBy').has('value', 'unused-code').count()`
+						`'unused-edition').in('usedBy').has('value', "unused-code").count()`
 					actualQry := calls[0].Q
 					So(actualQry, ShouldEqual, expectedQry)
 				})
@@ -398,7 +398,7 @@ func TestGetCode(t *testing.T) {
 			_, err := db.GetCode(context.Background(), unusedCodeList, unusedEdition, unusedCode)
 			expectedErr := `Gremlin query failed: "g.V().hasLabel('_code_list').has('listID', ` +
 				`'unused-code-list').has('edition', 'unused-edition').in('usedBy').has('value', ` +
-				`'unused-code').count()":  MALFORMED REQUEST `
+				`\"unused-code\").count()":  MALFORMED REQUEST `
 			Convey("Then the returned error should wrap the underlying one", func() {
 				So(err.Error(), ShouldEqual, expectedErr)
 			})

--- a/neptune/codelistsdataset.go
+++ b/neptune/codelistsdataset.go
@@ -70,7 +70,8 @@ func (n *NeptuneDB) GetCodeDatasets(ctx context.Context, codeListID, edition str
 createCodeDatasetRecords splits a list of strings into clumps of 4
 */
 func createCodeDatasetRecords(responses []string) ([][]string, error) {
-	return createRecords(responses, 4)
+	const valuesPerRecord = 4
+	return createRecords(responses, valuesPerRecord)
 }
 
 // These (nested) maps track the latest version cited by any combination

--- a/neptune/codelistsdataset.go
+++ b/neptune/codelistsdataset.go
@@ -50,7 +50,7 @@ func (n *NeptuneDB) GetCodeDatasets(ctx context.Context, codeListID, edition str
 
 	// Isolate the individual records from the flattened response.
 	// [['dim', 'edition', 'version', 'datasetID'], ['dim', 'edition', ...]]
-	responseRecords, err := createRecords(responses)
+	responseRecords, err := createCodeDatasetRecords(responses)
 	if err != nil {
 		return nil, errors.Wrap(err, "Cannot create records.")
 	}
@@ -67,22 +67,10 @@ func (n *NeptuneDB) GetCodeDatasets(ctx context.Context, codeListID, edition str
 }
 
 /*
-createRecords splits a list of strings into clumps of 4
+createCodeDatasetRecords splits a list of strings into clumps of 4
 */
-func createRecords(responses []string) ([][]string, error) {
-	var responseRecords = [][]string{}
-	const stride = 4 // I.e. dimesionName, edition, version, datasetID
-	if len(responses)%stride != 0 {
-		return nil, errors.New("List length is not divisible by 4")
-	}
-	for i := 0; i < len(responses); i += stride {
-		dimensionName := responses[i+0]
-		datasetEdition := responses[i+1]
-		versionStr := responses[i+2]
-		datasetID := responses[i+3]
-		responseRecords = append(responseRecords, []string{dimensionName, datasetEdition, versionStr, datasetID})
-	}
-	return responseRecords, nil
+func createCodeDatasetRecords(responses []string) ([][]string, error) {
+	return createRecords(responses, 4)
 }
 
 // These (nested) maps track the latest version cited by any combination

--- a/neptune/codelistsdataset_test.go
+++ b/neptune/codelistsdataset_test.go
@@ -44,7 +44,7 @@ func TestCreateTriples(t *testing.T) {
 		Convey("When createCodeDatasetRecords() is called", func() {
 			_, err := createCodeDatasetRecords(input)
 			Convey("Then an appropriate error should be returned", func() {
-				expectedErr := "List length is not divisible by 4"
+				expectedErr := "list length is not divisible by 4"
 				So(err.Error(), ShouldEqual, expectedErr)
 			})
 		})

--- a/neptune/codelistsdataset_test.go
+++ b/neptune/codelistsdataset_test.go
@@ -16,8 +16,8 @@ TestCreateTriples validates a helper utility function used by the API method.
 func TestCreateTriples(t *testing.T) {
 	Convey("Given an input list of 8 strings", t, func() {
 		input := []string{"a", "b", "c", "d", "e", "f", "g", "h"}
-		Convey("When createRecords() is called", func() {
-			triples, err := createRecords(input)
+		Convey("When createCodeDatasetRecords() is called", func() {
+			triples, err := createCodeDatasetRecords(input)
 			Convey("Then no error should be returned", func() {
 				So(err, ShouldBeNil)
 			})
@@ -29,8 +29,8 @@ func TestCreateTriples(t *testing.T) {
 	})
 	Convey("Given an empty input list", t, func() {
 		input := []string{}
-		Convey("When createRecords() is called", func() {
-			triples, err := createRecords(input)
+		Convey("When createCodeDatasetRecords() is called", func() {
+			triples, err := createCodeDatasetRecords(input)
 			Convey("Then no error should be returned", func() {
 				So(err, ShouldBeNil)
 			})
@@ -41,8 +41,8 @@ func TestCreateTriples(t *testing.T) {
 	})
 	Convey("Given a list with length that is not divisible by 4", t, func() {
 		input := []string{"a"}
-		Convey("When createRecords() is called", func() {
-			_, err := createRecords(input)
+		Convey("When createCodeDatasetRecords() is called", func() {
+			_, err := createCodeDatasetRecords(input)
 			Convey("Then an appropriate error should be returned", func() {
 				expectedErr := "List length is not divisible by 4"
 				So(err.Error(), ShouldEqual, expectedErr)

--- a/neptune/codelistsdataset_test.go
+++ b/neptune/codelistsdataset_test.go
@@ -218,14 +218,13 @@ func TestGetCodeDatasetsAtAPILevel(t *testing.T) {
 						has('edition','unusedEdition').
 						inE('usedBy').as('r').values('label').as('rl').select('r').
 						match(
-							__.as('r').outV().has('value','unusedCode').as('c'),
+							__.as('r').outV().has('value',"unusedCode").as('c'),
 							__.as('c').out('inDataset').as('d').
 								select('d').values('edition').as('de').
 								select('d').values('version').as('dv'),
 								select('d').values('dataset_id').as('did').
 							__.as('d').has('is_published',true)).
 						union(select('rl', 'de', 'dv', 'did')).unfold().select(values)
-
                     `)
 					actualQry := calls[0].Query
 					So(stripWhitespace(actualQry), ShouldEqual, expectedQry)

--- a/neptune/internal/mockpoolutils.go
+++ b/neptune/internal/mockpoolutils.go
@@ -113,6 +113,27 @@ var ReturnZeroVertices = func(query string, bindings map[string]string, rebindin
 	return []graphson.Vertex{}, nil
 }
 
+var ReturnEmptyCodesList = func(query string, bindings map[string]string, rebindings map[string]string) ([]string, error) {
+	return []string{}, nil
+}
+
+var ReturnInvalidCodeData = func(query string, bindings map[string]string, rebindings map[string]string) ([]string, error) {
+	var codes []string
+	codes = append(codes, "Not")
+	codes = append(codes, "Enough")
+	codes = append(codes, "Values")
+	return codes, nil
+}
+
+var ReturnThreeCodes = func(query string, bindings map[string]string, rebindings map[string]string) ([]string, error) {
+	var codes []string
+	for i := 0; i < 3; i++ {
+		codes = append(codes, fmt.Sprintf("label_%d", i))
+		codes = append(codes, fmt.Sprintf("code_%d", i))
+	}
+	return codes, nil
+}
+
 /*
 makeVertex makes a graphson.Vertex of a given type (e.g. "_code_list").
 */

--- a/neptune/query/query.go
+++ b/neptune/query/query.go
@@ -6,15 +6,17 @@ package query
 // 1) .property() function must contain 'single' where not a list, as the Neptune default is 'set'
 
 const (
-	// codelists
+	// code lists
 	GetCodeLists          = `g.V().hasLabel('_code_list')`
 	GetCodeListsFiltered  = `g.V().hasLabel('_code_list').has('%s', true)`
 	GetCodeList           = `g.V().hasLabel('_code_list').has('listID', '%s')`
 	CodeListExists        = `g.V().hasLabel('_code_list').has('listID', '%s').count()`
 	CodeListEditionExists = `g.V().hasLabel('_code_list').has('listID', '%s').has('edition', '%s').count()`
-	GetCodes              = `g.V().hasLabel('_code_list')` +
-		`.has('listID', '%s').has('edition', '%s')` +
-		`.in('usedBy').hasLabel('_code')`
+	GetCodes              = `g.V().has('_code_list','listID', '%s').has('edition', '%s')` +
+		`.inE("usedBy").as('usedBy')` +
+		`.outV().as('code')` +
+		`.select('usedBy', 'code').by('label').by('value')` +
+		`.unfold().select(values)`
 	CodeExists = `g.V().hasLabel('_code_list')` +
 		`.has('listID', '%s').has('edition', '%s')` +
 		`.in('usedBy').has('value', "%s").count()`
@@ -91,7 +93,6 @@ const (
 		`property(single,'edition','%s').property(single,'version','%d')`
 	SetInstanceIsPublished = `g.V().hasLabel('_%s_Instance').property(single,'is_published',true)`
 	CountObservations      = `g.V().hasLabel('_%s_observation').count()`
-
 
 	//instance - parts
 	AddInstanceDimensionsPart         = `g.V().hasLabel('_%s_Instance')`


### PR DESCRIPTION
### What

- Fix broken unit tests
- Update codes query to also return labels

The labels are stored on the edge between the code and code list, so the query now returns a flat list of strings, instead of the previous list of vertices.

### How to review
- Check tests pass
- Sanity check changes

(I have tested the changes locally against the code list API, and using the test instance of Neptune. The code will be integration tested on the cmd-dev environment.)

### Who can review
Anyone
