### PR TITLE
Map the label value in hierarchy nodes

### DIFF
--- a/neptune/hierarchy.go
+++ b/neptune/hierarchy.go
@@ -261,11 +261,11 @@ func (n *NeptuneDB) GetHierarchyRoot(ctx context.Context, instanceID, dimension 
 	}
 	var vertex graphson.Vertex
 	vertex = vertices[0]
-	// Note the call to buildHierarchyNodeFromGraphsonVertex below does much more than meets the eye,
+	// Note the call to buildHierarchyNode below does much more than meets the eye,
 	// including launching new queries in of itself to fetch child nodes, and
 	// breadcrumb nodes.
 	wantBreadcrumbs := false // Because meaningless for a root node
-	if node, err = n.buildHierarchyNodeFromGraphsonVertex(vertex, instanceID, dimension, wantBreadcrumbs); err != nil {
+	if node, err = n.buildHierarchyNode(vertex, instanceID, dimension, wantBreadcrumbs); err != nil {
 		log.Event(ctx, "Cannot extract related information needed from hierarchy node", log.ERROR, logData, log.Error(err))
 		return
 	}
@@ -287,11 +287,11 @@ func (n *NeptuneDB) GetHierarchyElement(ctx context.Context, instanceID, dimensi
 		log.Event(ctx, "Cannot find vertex when looking for specific hierarchy node", log.ERROR, logData, log.Error(err))
 		return
 	}
-	// Note the call to buildHierarchyNodeFromGraphsonVertex below does much more than meets the eye,
+	// Note the call to buildHierarchyNode below does much more than meets the eye,
 	// including launching new queries in of itself to fetch child nodes, and
 	// breadcrumb nodes.
 	wantBreadcrumbs := true // Because we are at depth in the hierarchy
-	if node, err = n.buildHierarchyNodeFromGraphsonVertex(vertex, instanceID, dimension, wantBreadcrumbs); err != nil {
+	if node, err = n.buildHierarchyNode(vertex, instanceID, dimension, wantBreadcrumbs); err != nil {
 		log.Event(ctx, "Cannot extract related information needed from hierarchy node", log.ERROR, logData, log.Error(err))
 		return
 	}

--- a/neptune/internal/mockpoolutils.go
+++ b/neptune/internal/mockpoolutils.go
@@ -134,6 +134,15 @@ var ReturnThreeCodes = func(query string, bindings map[string]string, rebindings
 	return codes, nil
 }
 
+func MakeHierarchyVertex(vertexLabel, code, codeLabel string, numberOfChildren int, hasData bool) graphson.Vertex {
+	vertex := makeVertex(vertexLabel)
+	setVertexStringProperty(&vertex, "code", code)
+	setVertexStringProperty(&vertex, "label", codeLabel)
+	setVertexTypedProperty("g:Int64", &vertex, "numberOfChildren", map[string]interface{}{"@type": "g:Int64", "@value": float64(numberOfChildren)})
+	setVertexTypedProperty("bool", &vertex, "hasData", hasData)
+	return vertex
+}
+
 /*
 makeVertex makes a graphson.Vertex of a given type (e.g. "_code_list").
 */

--- a/neptune/mapper.go
+++ b/neptune/mapper.go
@@ -41,13 +41,7 @@ func (n *NeptuneDB) buildHierarchyNode(v graphson.Vertex, instanceID, dimension 
 	}
 	// Fetch new data from the database concerned with the node's children.
 	if res.NoOfChildren > 0 && instanceID != "" {
-		var code string
-		if code, err = v.GetProperty("code"); err != nil {
-			log.Event(ctx, "bad GetProp code", log.ERROR, logData, log.Error(err))
-			return
-		}
-
-		gremStmt := fmt.Sprintf(query.GetChildren, instanceID, dimension, code)
+		gremStmt := fmt.Sprintf(query.GetChildren, instanceID, dimension, res.ID)
 		logData["statement"] = gremStmt
 
 		var childVertices []graphson.Vertex
@@ -120,7 +114,7 @@ func convertVertexToElement(v graphson.Vertex) (res *models.HierarchyElement, er
 		return
 	}
 
-	if res.Label, err = v.GetLabel(); err != nil {
+	if res.Label, err = v.GetProperty("label"); err != nil {
 		log.Event(ctx, "bad label", log.ERROR, logData, log.Error(err))
 		return
 	}

--- a/neptune/mapper.go
+++ b/neptune/mapper.go
@@ -14,9 +14,9 @@ import (
 	"github.com/ONSdigital/log.go/log"
 )
 
-func (n *NeptuneDB) buildHierarchyNodeFromGraphsonVertex(v graphson.Vertex, instanceID, dimension string, wantBreadcrumbs bool) (res *models.HierarchyResponse, err error) {
+func (n *NeptuneDB) buildHierarchyNode(v graphson.Vertex, instanceID, dimension string, wantBreadcrumbs bool) (res *models.HierarchyResponse, err error) {
 	ctx := context.Background()
-	logData := log.Data{"fn": "buildHierarchyNodeFromGraphsonVertex"}
+	logData := log.Data{"fn": "buildHierarchyNode"}
 
 	res = &models.HierarchyResponse{}
 	// Note we are using the vertex' *code* property for the response model's
@@ -27,7 +27,7 @@ func (n *NeptuneDB) buildHierarchyNodeFromGraphsonVertex(v graphson.Vertex, inst
 		return
 	}
 
-	if res.Label, err = v.GetLabel(); err != nil {
+	if res.Label, err = v.GetProperty("label"); err != nil {
 		log.Event(ctx, "bad label", log.ERROR, logData, log.Error(err))
 		return
 	}

--- a/neptune/mapper_test.go
+++ b/neptune/mapper_test.go
@@ -1,0 +1,84 @@
+package neptune
+
+import (
+	"github.com/ONSdigital/dp-graph/v2/neptune/internal"
+	"github.com/ONSdigital/graphson"
+	. "github.com/smartystreets/goconvey/convey"
+	"testing"
+)
+
+func Test_buildHierarchyNode(t *testing.T) {
+
+	poolMock := &internal.NeptunePoolMock{GetFunc: internal.ReturnThreeCodeLists}
+	db := mockDB(poolMock)
+
+	Convey("Given an example vertex returned from neptune", t, func() {
+
+		expectedLabel := "code-label"
+		expectedCode := "code"
+		vertex := makeDummyVertex("test-id", "vertex-label",
+			map[string]interface{}{
+				"code":             expectedCode,
+				"label":            expectedLabel,
+				"numberOfChildren": map[string]interface{}{"@type": "g:Int64", "@value": float64(0)},
+				"hasData":          true,
+			})
+		wantBreadcrumbs := false
+		dimension := "dimension"
+		instanceID := "instance-id"
+
+		Convey("When buildHierarchyNode is called", func() {
+
+			hierarchyNode, err := db.buildHierarchyNode(vertex, instanceID, dimension, wantBreadcrumbs)
+
+			Convey("Then the expected values are mapped onto the returned hierarchy response", func() {
+				So(err, ShouldBeNil)
+				So(hierarchyNode.ID, ShouldEqual, expectedCode)
+				So(hierarchyNode.Label, ShouldEqual, expectedLabel)
+				So(hierarchyNode.NoOfChildren, ShouldEqual, 0)
+				So(hierarchyNode.HasData, ShouldEqual, true)
+			})
+		})
+	})
+}
+
+func makeDummyVertex(vertexID, vertexLabel string, params map[string]interface{}) graphson.Vertex {
+	properties := make(map[string][]graphson.VertexProperty)
+	for label, value := range params {
+		var vp []graphson.VertexProperty
+		vSlice, ok := value.([]interface{})
+		if ok {
+			for _, p := range vSlice {
+				vertexProperty := makeDummyVertexProperty(label, p)
+				vp = append(vp, vertexProperty)
+			}
+		} else {
+			vertexProperty := makeDummyVertexProperty(label, value)
+			vp = append(vp, vertexProperty)
+		}
+		properties[label] = vp
+	}
+	vertexValue := graphson.VertexValue{
+		ID:         vertexID,
+		Label:      vertexLabel,
+		Properties: properties,
+	}
+	return graphson.Vertex{
+		Type:  "g:Vertex",
+		Value: vertexValue,
+	}
+}
+
+func makeDummyVertexProperty(label string, value interface{}) graphson.VertexProperty {
+	return graphson.VertexProperty{
+		Type: "g:VertexProperty",
+		Value: graphson.VertexPropertyValue{
+			ID: graphson.GenericValue{
+				Type:  "Type",
+				Value: 1,
+			},
+			Value: value,
+			Label: label,
+		},
+	}
+}


### PR DESCRIPTION
### What
- The incorrect value for a hierarchy node's label was being mapped. This PR fixes the mapping of the label so the label is returned.
- Added test coverage to mapping logic

The mapping is a bit confusing within Neptune as Neptune has it's own concept of a label, and this is what was previously being mapped. The label we want returned is stored as a property on the vertex.

### How to review
- Review changes
- Check the unit tests pass 

### Who can review
If what I mentioned above makes any sense to you, hopefully you can ;)
