### PR TITLE
Return the defined `not found` error when a vertex is not found.

### DIFF
--- a/neptune/neptune_test.go
+++ b/neptune/neptune_test.go
@@ -1,0 +1,26 @@
+package neptune
+
+import (
+	"github.com/ONSdigital/dp-graph/v2/graph/driver"
+	"github.com/ONSdigital/dp-graph/v2/neptune/internal"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNeptuneDB_getVertex(t *testing.T) {
+
+	Convey("Given a mocked neptune DB that returns an empty vertex array", t, func() {
+
+		poolMock := &internal.NeptunePoolMock{GetFunc: internal.ReturnZeroVertices}
+		db := mockDB(poolMock)
+
+		Convey("When getVertex is called", func() {
+			_, err := db.getVertex("gremlin statement")
+
+			Convey("Then ErrNotFound is returned", func() {
+				So(err, ShouldEqual, driver.ErrNotFound)
+			})
+		})
+	})
+}


### PR DESCRIPTION
### What
Return the defined `not found` error when a vertex is not found, instead of a custom error type.
This was changed particularly for the case where a hierarchy is retrieved to check if it exists. This caused a lookup of the root hierarchy which failed with a custom error, which did not translate into a 404 response but a 500.

### How to review
Review changes + unit test

### Who can review
Anyone
