### PR TITLE
Fix statement to tag nodes to keep when trimming hierarchies

### DIFF
--- a/neptune/query/query.go
+++ b/neptune/query/query.go
@@ -71,7 +71,7 @@ const (
 	GetCodesWithData = `g.V().hasLabel('_%s_%s').values('value')`
 	SetHasData       = `g.V().hasLabel('_hierarchy_node_%s_%s').as('v').has('code',within(%s)).property(single,'hasData',true)`
 
-	MarkNodesToRemain = `g.V().hasLabel('_hierarchy_node_%s_%s').has('hasData').property(single,'remain',true)` +
+	MarkNodesToRemain = `g.V().hasLabel('_hierarchy_node_%s_%s').has('hasData', true).property(single,'remain',true)` +
 		`.repeat(out('hasParent')).emit().property(single,'remain',true)`
 	RemoveNodesNotMarkedToRemain = `g.V().hasLabel('_hierarchy_node_%s_%s').not(has('remain',true)).drop()`
 	RemoveRemainMarker           = `g.V().hasLabel('_hierarchy_node_%s_%s').has('remain').properties('remain').drop()`


### PR DESCRIPTION
### What
Fix statement to tag nodes to keep when trimming hierarchies
- all nodes are given a value for hasData. The previous statement just checked for the presence of the hasData property, not that it was explicitly true. This caused nodes that had no data to be kept when they should be removed.

### How to review
Sanity check

### Who can review
Anyone