### PR TITLE
Add error_consumer type to help consume graph DB errors

### DIFF
--- a/graph/error_consumer.go
+++ b/graph/error_consumer.go
@@ -1,0 +1,57 @@
+package graph
+
+import (
+	"context"
+	"errors"
+	"github.com/ONSdigital/log.go/log"
+)
+
+var ErrContextDone = errors.New("context done while closing error consumer")
+
+// ErrorConsumer maintains a go routine to consume an error channel
+type ErrorConsumer struct {
+	closing chan interface{}
+	closed  chan interface{}
+}
+
+func NewLoggingErrorConsumer(ctx context.Context, errors chan error) *ErrorConsumer {
+	return NewErrorConsumer(errors, func(err error) {
+		log.Event(ctx, "error from graph DB", log.ERROR, log.Error(err))
+	})
+}
+
+// NewErrorConsumer starts a new go routine to consume errors
+func NewErrorConsumer(errors chan error, consume func(error)) *ErrorConsumer {
+
+	c := &ErrorConsumer{
+		closing: make(chan interface{}),
+		closed:  make(chan interface{}),
+	}
+
+	go func() {
+		defer close(c.closed)
+
+		for {
+			select {
+			case err := <-errors:
+				consume(err)
+			case <-c.closing:
+				return
+			}
+		}
+	}()
+
+	return c
+}
+
+// Close blocks until the go routine has finished
+func (c *ErrorConsumer) Close(ctx context.Context) error {
+	close(c.closing)
+
+	select {
+	case <-c.closed:
+		return nil
+	case <-ctx.Done():
+		return ErrContextDone
+	}
+}

--- a/graph/error_consumer_test.go
+++ b/graph/error_consumer_test.go
@@ -1,0 +1,96 @@
+package graph
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestChannelConsumer_Close(t *testing.T) {
+
+	ctx, _ := context.WithTimeout(context.Background(), time.Millisecond*200)
+	errorChan := make(chan error, 1)
+	consume := func(error) {}
+
+	Convey("Given a channel consumer", t, func() {
+
+		errorConsumer := NewErrorConsumer(errorChan, consume)
+
+		Convey("When close is called", func() {
+
+			err := errorConsumer.Close(ctx)
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+			})
+		})
+	})
+}
+
+func TestChannelConsumer_CloseContext(t *testing.T) {
+
+	ctx, _ := context.WithTimeout(context.Background(), time.Millisecond*10)
+	errorChan := make(chan error, 1)
+
+	consumeFinished := false
+	consume := func(error) {
+		time.Sleep(time.Second)
+		consumeFinished = true
+	}
+
+	Convey("Given a channel consumer on a long running function", t, func() {
+
+		errorConsumer := NewErrorConsumer(errorChan, consume)
+		errorChan <- errors.New("")
+
+		Convey("When close is called", func() {
+
+			err := errorConsumer.Close(ctx)
+
+			Convey("Then a context timeout error is returned", func() {
+				So(errors.Is(err, ErrContextDone), ShouldBeTrue)
+			})
+
+			Convey("Then the consume function did not finish", func() {
+				So(consumeFinished, ShouldBeFalse)
+			})
+		})
+	})
+}
+
+func TestNewChannelConsumer(t *testing.T) {
+
+	consumeCalled := false
+	consumeFinished := make(chan interface{})
+
+	errorChan := make(chan error, 1)
+	consume := func(error) {
+		consumeCalled = true
+		consumeFinished <- nil
+	}
+
+	ctx, _ := context.WithTimeout(context.Background(), time.Millisecond*200)
+
+	Convey("Given a channel consumer", t, func() {
+
+		errorConsumer := NewErrorConsumer(errorChan, consume)
+		defer errorConsumer.Close(ctx)
+
+		Convey("When an error is available on the configured channel", func() {
+
+			errorChan <- errors.New("")
+
+			select {
+			case <-consumeFinished:
+			case <-ctx.Done():
+			}
+
+			Convey("Then the consumer function is called", func() {
+				So(consumeCalled, ShouldBeTrue)
+			})
+		})
+	})
+}


### PR DESCRIPTION
### What
We are not currently consuming any errors that are put on the error channel. Instead of having this code in each service I have put it into a reusable type. If the errors are not consumed from the channel, the graph driver locks up.

Add error_consumer type to easily consume graph DB errors
- creates a separate go routine to consume errors
- constructor function to create a standard logging consumer
- provides a blocking close method for graceful shutdown


### How to review
Review changes

### Who can review
Anyone