### PR TITLE
Use single quotes for observation values

### DIFF
--- a/neptune/query/query.go
+++ b/neptune/query/query.go
@@ -107,8 +107,8 @@ const (
 		`.addE('HAS_DIMENSION').to('inst').select('d')`
 
 	// observation
-	DropObservationRelationships   = `g.V().hasLabel('_%s_observation').has('value', "%s").bothE().drop().iterate();`
-	DropObservation                = `g.V().hasLabel('_%s_observation').has('value', "%s").drop().iterate();`
+	DropObservationRelationships   = `g.V().hasLabel('_%s_observation').has('value', '%s').bothE().drop().iterate();`
+	DropObservation                = `g.V().hasLabel('_%s_observation').has('value', '%s').drop().iterate();`
 	CreateObservationPart          = `g.addV('_%s_observation').as('o').property(single, 'value', '%s').property(single, 'rowIndex', '%d')`
 	AddObservationRelationshipPart = `.V().hasId('%s').hasLabel('_%s_%s').where(values('value').is("%s")).addE('isValueOf').from('o')`
 


### PR DESCRIPTION
### What
Values can contain various characters that need escaping when using double quotes. Using single quotes is a safer option as much of the escaping is not required. 

Use single quotes for observation values
- when using single quotes, the only characters that need to be escaped are single quotes.

### How to review
Sanity check

### Who can review
Anyone