### PR TITLE
Fix/neptune filter performance

### DIFF
--- a/neptune/dimension.go
+++ b/neptune/dimension.go
@@ -25,7 +25,12 @@ func (n *NeptuneDB) InsertDimension(ctx context.Context, uniqueDimensions map[st
 
 	createDimension := fmt.Sprintf(query.DropDimensionRelationships, instanceID, d.DimensionID, d.Option)
 	createDimension += fmt.Sprintf(query.DropDimension, instanceID, d.DimensionID, d.Option)
-	createDimension += fmt.Sprintf(query.CreateDimensionToInstanceRelationship, instanceID, instanceID, d.DimensionID, d.Option)
+	createDimension += fmt.Sprintf(query.CreateDimensionToInstanceRelationship,
+		instanceID,                // instance node
+		instanceID, d.DimensionID, // label
+		instanceID, d.DimensionID, d.Option, // option specific ID
+		d.Option, // value property
+	)
 
 	res, err := n.getVertex(createDimension)
 

--- a/neptune/observation.go
+++ b/neptune/observation.go
@@ -36,7 +36,7 @@ func (n *NeptuneDB) StreamCSVRows(ctx context.Context, instanceID, filterID stri
 
 	q := fmt.Sprintf(query.GetInstanceHeaderPart, instanceID)
 	q += buildObservationsQuery(instanceID, filter)
-	q += query.GetObservationSelectPart
+	q += query.GetObservationValuesPart
 
 	if limit != nil {
 		q += fmt.Sprintf(query.LimitPart, *limit)

--- a/neptune/observation_test.go
+++ b/neptune/observation_test.go
@@ -39,7 +39,7 @@ func Test_buildObservationsQuery(t *testing.T) {
 			result := buildObservationsQuery(instanceID, filter)
 
 			Convey("Then the resulting query portion should filter to relevant observations", func() {
-				So(result, ShouldEqual, ".V().has('_888_age','value',within('30')).in('isValueOf')")
+				So(result, ShouldEqual, ".V().hasId('_888_age_30').in('isValueOf')")
 			})
 		})
 	})
@@ -58,10 +58,9 @@ func Test_buildObservationsQuery(t *testing.T) {
 			result := buildObservationsQuery(instanceID, filter)
 
 			Convey("Then the resulting query portion should filter to relevant observations", func() {
-				expectedQuery := `.V().has('_888_age','value',within('29','30','31')).in('isValueOf').` +
-					`match(` +
-					`__.as('row').out('isValueOf').has('_888_sex','value',within('male','female','all')),` +
-					`__.as('row').out('isValueOf').has('_888_geography','value',within('K0001','K0002','K0003')))`
+				expectedQuery := `.V().hasId('_888_age_29','_888_age_30','_888_age_31').in('isValueOf')` +
+					`.where(out('isValueOf').hasId('_888_sex_male','_888_sex_female','_888_sex_all','_888_geography_K0001','_888_geography_K0002','_888_geography_K0003')` +
+					`.fold().count(local).is_(2))`
 				So(result, ShouldEqual, expectedQuery)
 			})
 		})

--- a/neptune/query/query.go
+++ b/neptune/query/query.go
@@ -103,7 +103,7 @@ const (
 	DropDimensionRelationships            = `g.V().hasLabel('_%s_%s').has('value', "%s").bothE().drop().iterate();`
 	DropDimension                         = `g.V().hasLabel('_%s_%s').has('value', "%s").drop().iterate();`
 	CreateDimensionToInstanceRelationship = `g.V().hasLabel('_%s_Instance').as('inst')` +
-		`.addV('_%s_%s').as('d').property('value',"%s")` +
+		`.addV('_%s_%s').as('d').property(id, '_%s_%s_%s').property('value',"%s")` +
 		`.addE('HAS_DIMENSION').to('inst').select('d')`
 
 	// observation

--- a/neptune/query/query.go
+++ b/neptune/query/query.go
@@ -112,11 +112,10 @@ const (
 	CreateObservationPart          = `g.addV('_%s_observation').as('o').property(single, 'value', '%s').property(single, 'rowIndex', '%d')`
 	AddObservationRelationshipPart = `.V().hasId('%s').hasLabel('_%s_%s').where(values('value').is("%s")).addE('isValueOf').from('o')`
 
-	GetInstanceHeaderPart  = `g.V().hasLabel('_%s_Instance').values('header').aggregate('results')`
-	GetAllObservationsPart = `.V().hasLabel('_%s_observation').values('row')`
-
-	GetFirstDimensionPart       = `.V().has('_%s_%s','value',within(%s)).in('isValueOf')`
-	GetObservationDimensionPart = `__.as('row').out('isValueOf').has('_%s_%s','value',within(%s))`
-	GetObservationSelectRowPart = `.select('row').by('value').aggregate('results').cap('results').unfold()`
+	GetInstanceHeaderPart       = `g.V().hasLabel('_%s_Instance').values('header').aggregate('results')`
+	GetAllObservationsPart      = `.V().hasLabel('_%s_observation').values('row')`
+	GetFirstDimensionPart       = `.V().hasId(%s).in('isValueOf')`
+	GetAdditionalDimensionsPart = `.where(out('isValueOf').hasId(%s).fold().count(local).is_(%d))`
+	GetObservationSelectPart    = `.values('value').aggregate('results').cap('results').unfold()`
 	LimitPart                   = `.limit(%d)`
 )

--- a/neptune/query/query.go
+++ b/neptune/query/query.go
@@ -116,6 +116,6 @@ const (
 	GetAllObservationsPart      = `.V().hasLabel('_%s_observation').values('row')`
 	GetFirstDimensionPart       = `.V().hasId(%s).in('isValueOf')`
 	GetAdditionalDimensionsPart = `.where(out('isValueOf').hasId(%s).fold().count(local).is_(%d))`
-	GetObservationSelectPart    = `.values('value').aggregate('results').cap('results').unfold()`
+	GetObservationValuesPart    = `.values('value').aggregate('results').cap('results').unfold()`
 	LimitPart                   = `.limit(%d)`
 )


### PR DESCRIPTION
### What
- Add a unique ID property when creating dimension nodes in the graph, allowing the filter query to be more performant
- update the filter query to utilise the ID property and not use the unoptimised match step
- all dimension option ID's (other than the first dimension) are bundled together in the where clause

### How to review
Sanity check the changes

### Who can review
Anyone
