### PR TITLE
Split CSV header query from observations

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -14,7 +14,7 @@ import (
 // relevant driver for further setup
 type Configuration struct {
 	DriverChoice    string `envconfig:"GRAPH_DRIVER_TYPE"`
-	DatabaseAddress string `envconfig:"GRAPH_ADDR"`
+	DatabaseAddress string `envconfig:"GRAPH_ADDR" json:"-"`
 	PoolSize        int    `envconfig:"GRAPH_POOL_SIZE"`
 	MaxRetries      int    `envconfig:"MAX_RETRIES"`
 	QueryTimeout    int    `envconfig:"GRAPH_QUERY_TIMEOUT"`

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module github.com/ONSdigital/dp-graph/v2
 go 1.13
 
 require (
-	github.com/ONSdigital/dp-healthcheck v1.0.2
+	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/golang-neo4j-bolt-driver v0.0.0-20190228153339-da534111531d
 	github.com/ONSdigital/graphson v0.0.0-20190718134034-c13ceacd109d
 	github.com/ONSdigital/gremgo-neptune v1.0.0
-	github.com/ONSdigital/log.go v1.0.0
+	github.com/ONSdigital/log.go v1.0.1
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/pkg/errors v0.9.1
 	github.com/smartystreets/goconvey v1.6.4

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,9 @@
-github.com/ONSdigital/dp-healthcheck v1.0.2 h1:N8SzpYzdixVgJS9NMzTBA2RZ2bi3Am1wE5F8ROEpTYw=
-github.com/ONSdigital/dp-healthcheck v1.0.2/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
-github.com/ONSdigital/dp-rchttp v0.0.0-20190919143000-bb5699e6fd59/go.mod h1:KkW68U3FPuivW4ogi9L8CPKNj9ZxGko4qcUY7KoAAkQ=
+github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=
+github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=
+github.com/ONSdigital/dp-net v1.0.5-0.20200805082802-e518bc287596/go.mod h1:wDVhk2pYosQ1q6PXxuFIRYhYk2XX5+1CeRRnXpSczPY=
+github.com/ONSdigital/dp-net v1.0.5-0.20200805145012-9227a11caddb/go.mod h1:MrSZwDUvp8u1VJEqa+36Gwq4E7/DdceW+BDCvGes6Cs=
+github.com/ONSdigital/dp-net v1.0.5-0.20200805150805-cac050646ab5 h1:JqZtDTXQJZ48WNG+VVs3+H2qVymOVuotfRmOp+mm02I=
+github.com/ONSdigital/dp-net v1.0.5-0.20200805150805-cac050646ab5/go.mod h1:de3LB9tedE0tObBwa12dUOt5rvTW4qQkF5rXtt4b6CE=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58 h1:XHnzoC7TxueLAfkBpblPiwaIxjngGv1VNVZhvE4jY6w=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/golang-neo4j-bolt-driver v0.0.0-20190228153339-da534111531d h1:Z0FsB7q0SG3tG4O/WGv0hh1MyxScyZ5JWjECEgVCIzM=
@@ -9,10 +12,13 @@ github.com/ONSdigital/graphson v0.0.0-20190718134034-c13ceacd109d h1:yrCtEGlohmA
 github.com/ONSdigital/graphson v0.0.0-20190718134034-c13ceacd109d/go.mod h1:zQ+8pTnCLGuy4eUek81pWUxZo4/f71ri3VYz97Wby+4=
 github.com/ONSdigital/gremgo-neptune v1.0.0 h1:l0Pizt2goXK5oCFeqs2sOkosZbF4sva0RpcR150VvNE=
 github.com/ONSdigital/gremgo-neptune v1.0.0/go.mod h1:GZz/N6xjNY+EN0x4FmfBDrM73R+Pr3aI5iCwYbY1oYQ=
-github.com/ONSdigital/log.go v0.0.0-20191127134126-2a610b254f20/go.mod h1:BD7D8FWP1fzwUWsrCopEG72jl9cchCaVNIGSz6YvL+Y=
 github.com/ONSdigital/log.go v1.0.0 h1:hZQTuitFv4nSrpzMhpGvafUC5/8xMVnLI0CWe1rAJNc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
-github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=
+github.com/ONSdigital/log.go v1.0.1-0.20200805145532-1f25087a0744/go.mod h1:y4E9MYC+cV9VfjRD0UBGj8PA7H3wABqQi87/ejrDhYc=
+github.com/ONSdigital/log.go v1.0.1 h1:SZ5wRZAwlt2jQUZ9AUzBB/PL+iG15KapfQpJUdA18/4=
+github.com/ONSdigital/log.go v1.0.1/go.mod h1:dIwSXuvFB5EsZG5x44JhsXZKMd80zlb0DZxmiAtpL4M=
+github.com/facebookgo/freeport v0.0.0-20150612182905-d4adf43b75b9/go.mod h1:uPmAp6Sws4L7+Q/OokbWDAK1ibXYhB3PXFP1kol5hPg=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
@@ -25,6 +31,7 @@ github.com/hokaccha/go-prettyjson v0.0.0-20190818114111-108c894c2c0e h1:0aewS5NT
 github.com/hokaccha/go-prettyjson v0.0.0-20190818114111-108c894c2c0e/go.mod h1:pFlLw2CfqZiIBOx6BuCeRLCrfxBJipTY0nIOF/VbGcI=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/justinas/alice v1.2.0/go.mod h1:fN5HRH/reO/zrUflLfTN43t3vXvKzvZIENsNEe7i7qA=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
@@ -33,6 +40,7 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.11 h1:FxPOTFNqGkuDUGi3H/qkUbQO4ZiBa2brKq5r0l8TGeM=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
+github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -43,9 +51,12 @@ github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIK
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"context"
 	"errors"
+	"github.com/ONSdigital/log.go/log"
 
 	"github.com/ONSdigital/dp-graph/v2/config"
 	"github.com/ONSdigital/dp-graph/v2/graph/driver"
@@ -67,6 +68,8 @@ func New(ctx context.Context, choice Subsets) (*DB, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	log.Event(ctx, "loaded graph database config", log.INFO, log.Data{"config": cfg})
 
 	var ok bool
 	var codelist driver.CodeList

--- a/neptune/observation_test.go
+++ b/neptune/observation_test.go
@@ -39,7 +39,7 @@ func Test_buildObservationsQuery(t *testing.T) {
 			result := buildObservationsQuery(instanceID, filter)
 
 			Convey("Then the resulting query portion should filter to relevant observations", func() {
-				So(result, ShouldEqual, ".V().hasId('_888_age_30').in('isValueOf')")
+				So(result, ShouldEqual, "g.V().hasId('_888_age_30').in('isValueOf')")
 			})
 		})
 	})
@@ -58,7 +58,7 @@ func Test_buildObservationsQuery(t *testing.T) {
 			result := buildObservationsQuery(instanceID, filter)
 
 			Convey("Then the resulting query portion should filter to relevant observations", func() {
-				expectedQuery := `.V().hasId('_888_age_29','_888_age_30','_888_age_31').in('isValueOf')` +
+				expectedQuery := `g.V().hasId('_888_age_29','_888_age_30','_888_age_31').in('isValueOf')` +
 					`.where(out('isValueOf').hasId('_888_sex_male','_888_sex_female','_888_sex_all','_888_geography_K0001','_888_geography_K0002','_888_geography_K0003')` +
 					`.fold().count(local).is_(2))`
 				So(result, ShouldEqual, expectedQuery)

--- a/neptune/query/query.go
+++ b/neptune/query/query.go
@@ -112,10 +112,10 @@ const (
 	CreateObservationPart          = `g.addV('_%s_observation').as('o').property(single, 'value', '%s').property(single, 'rowIndex', '%d')`
 	AddObservationRelationshipPart = `.V().hasId('%s').addE('isValueOf').from('o')`
 
-	GetInstanceHeaderPart       = `g.V().hasId('_%s_Instance').values('header').aggregate('results')`
-	GetAllObservationsPart      = `.V().hasLabel('_%s_observation')`
-	GetFirstDimensionPart       = `.V().hasId(%s).in('isValueOf')`
+	GetInstanceHeaderPart       = `g.V().hasId('_%s_Instance').values('header')`
+	GetAllObservationsPart      = `g.V().hasLabel('_%s_observation')`
+	GetFirstDimensionPart       = `g.V().hasId(%s).in('isValueOf')`
 	GetAdditionalDimensionsPart = `.where(out('isValueOf').hasId(%s).fold().count(local).is_(%d))`
-	GetObservationValuesPart    = `.values('value').aggregate('results').cap('results').unfold()`
+	GetObservationValuesPart    = `.values('value')`
 	LimitPart                   = `.limit(%d)`
 )

--- a/observation/composite_row_reader.go
+++ b/observation/composite_row_reader.go
@@ -1,0 +1,54 @@
+package observation
+
+import (
+	"context"
+	"io"
+)
+
+var _ StreamRowReader = (*CompositeRowReader)(nil)
+
+// CompositeRowReader abstracts multiple StreamRowReader's to act as one
+type CompositeRowReader struct {
+	readers     []StreamRowReader
+	readerIndex int
+}
+
+func NewCompositeRowReader(readers ...StreamRowReader) *CompositeRowReader {
+	return &CompositeRowReader{
+		readers:     readers,
+		readerIndex: 0,
+	}
+}
+
+func (c *CompositeRowReader) Read() (row string, err error) {
+
+	// attempt to read from the current reader
+	row, err = c.readers[c.readerIndex].Read()
+
+	// if the current reader is EOF, move to the next reader
+	if err == io.EOF {
+		c.readerIndex++
+
+		// if there is no more readers, return EOF
+		if c.readerIndex == len(c.readers) {
+			return "", io.EOF
+		}
+
+		// recursive call to read from the next reader
+		return c.Read()
+	} else if err != nil {
+		return "", err
+	}
+
+	return row, nil
+}
+
+func (c *CompositeRowReader) Close(ctx context.Context) error {
+	for i := range c.readers {
+		err := c.readers[i].Close(ctx)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/observation/composite_row_reader_test.go
+++ b/observation/composite_row_reader_test.go
@@ -1,0 +1,56 @@
+package observation_test
+
+import (
+	"github.com/ONSdigital/dp-graph/v2/observation"
+	"github.com/ONSdigital/dp-graph/v2/observation/observationtest"
+	. "github.com/smartystreets/goconvey/convey"
+	"io"
+	"testing"
+)
+
+func TestCompositeRowReader_Read(t *testing.T) {
+
+	Convey("Given a composite reader with a mock header and observation reader", t, func() {
+
+		headerContent := "header1,header2,header3"
+		headerRead := false
+		mockHeaderReader := &observationtest.StreamRowReaderMock{
+			ReadFunc: func() (string, error) {
+				if headerRead {
+					return "", io.EOF
+				}
+				headerRead = true
+				return headerContent, nil
+			},
+		}
+
+		rowContent := "csv,row,content"
+		rowRead := false
+		mockRowReader := &observationtest.StreamRowReaderMock{
+			ReadFunc: func() (string, error) {
+				if rowRead {
+					return "", io.EOF
+				}
+				rowRead = true
+				return rowContent, nil
+			},
+		}
+
+		reader := observation.NewCompositeRowReader(mockHeaderReader, mockRowReader)
+
+		Convey("When read is called", func() {
+
+			row, err := reader.Read()
+			So(err, ShouldBeNil)
+			So(row, ShouldEqual, headerContent)
+
+			row, err = reader.Read()
+			So(err, ShouldBeNil)
+			So(row, ShouldEqual, rowContent)
+
+			row, err = reader.Read()
+			So(err, ShouldEqual, io.EOF)
+			So(row, ShouldEqual, "")
+		})
+	})
+}


### PR DESCRIPTION
### What

- Upgrade ONSdigital dependencies
- Log the graph config on initialisation (without the address field)
- Read the CSV header separate from the observation rows in Neptune
   - There is a performance issue with aggregating the header row with the observation rows.
   - Introduced a generic type that composes a number of readers to act as one.

### How to review
Sanity check, check tests pass

### Who can review
Anyone
