### PR TITLE
Fix bug where multiple quotes are not correctly escaped

### DIFF
--- a/neptune/observation.go
+++ b/neptune/observation.go
@@ -144,10 +144,5 @@ func (n *NeptuneDB) InsertObservationBatch(ctx context.Context, attempt int, ins
 }
 
 func escapeSingleQuotes(input string) string {
-	for i, c := range input {
-		if string(c) == "'" {
-			input = input[:i] + "\\" + input[i:]
-		}
-	}
-	return input
+	return strings.Replace(input, "'", "\\'", -1)
 }

--- a/neptune/observation_test.go
+++ b/neptune/observation_test.go
@@ -113,5 +113,35 @@ func Test_StreamCSVRows(t *testing.T) {
 			})
 		})
 	})
+}
 
+func Test_escapeSingleQuotes(t *testing.T) {
+
+	Convey("Given a value with a single quote", t, func() {
+
+		value := "carl's"
+		expected := "carl\\'s"
+
+		Convey("When escapeSingleQuotes is called", func() {
+			actual := escapeSingleQuotes(value)
+
+			Convey("Then single quote is escaped", func() {
+				So(actual, ShouldEqual, expected)
+			})
+		})
+	})
+
+	Convey("Given a value with multiple single quotes", t, func() {
+
+		value := "83.8,,1999,1999,E07000146,King's Lynn and West Norfolk,68IMP,68IMP : Owner-occupiers' imputed rental,chained-volume-measures-index,Chained volume measures index"
+		expected := "83.8,,1999,1999,E07000146,King\\'s Lynn and West Norfolk,68IMP,68IMP : Owner-occupiers\\' imputed rental,chained-volume-measures-index,Chained volume measures index"
+
+		Convey("When escapeSingleQuotes is called", func() {
+			actual := escapeSingleQuotes(value)
+
+			Convey("Then each single quote is correctly escaped", func() {
+				So(actual, ShouldEqual, expected)
+			})
+		})
+	})
 }


### PR DESCRIPTION
### What
When observations are inserted into the graph DB, and single quotes within the value need to be escaped. This was working fine when only one single quote was in the value, but multiple single quotes caused the escaping backslash to be inserted at the wrong index in the string.

This fix ensures that multiple single quotes in a single value are escaped correctly.

### How to review
Review changes / check tests

### Who can review
Anyone
