### PR TITLE
Add function to return error channel

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -24,6 +24,11 @@ type DB struct {
 	Errors chan error
 }
 
+// ErrorChan returns the error channel associated with this DB
+func (db DB) ErrorChan() chan error {
+	return db.Errors
+}
+
 // Subsets allows a clear and concise way of requesting any combination of
 // functionality by groups of node types
 type Subsets struct {


### PR DESCRIPTION
### What
Add function to return error channel
- allows the error channel to be added to interfaces within services.

A number of services have interfaces defined for the graph DB. This function has been added so that these interfaces can define the function, instead of having to use the concrete type to access the error channel.

I have intentionally left the struct member public, as to not break backwards compatibility.

### How to review
Sanity check

### Who can review
Anyone
