### PR TITLE
implemented new methods to perform the new hierarchy build algorithm

### DIFF
--- a/graph/driver/driver.go
+++ b/graph/driver/driver.go
@@ -28,22 +28,29 @@ type CodeList interface {
 
 // Hierarchy defines functions to create and retrieve generic and instance hierarchy nodes
 type Hierarchy interface {
-	CreateInstanceHierarchyConstraints(ctx context.Context, attempt int, instanceID, dimensionName string) error
+	// read
+	GetHierarchyCodelist(ctx context.Context, instanceID, dimension string) (string, error)
+	GetHierarchyRoot(ctx context.Context, instanceID, dimension string) (*models.HierarchyResponse, error)
+	GetHierarchyElement(ctx context.Context, instanceID, dimension, code string) (*models.HierarchyResponse, error)
 	GetCodesWithData(ctx context.Context, attempt int, instanceID, dimensionName string) (codes []string, err error)
 	GetGenericHierarchyNodeIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs []string, err error)
 	GetGenericHierarchyAncestriesIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs []string, err error)
-	CloneNodes(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string, ids []string, hasData bool) (err error)
 	CountNodes(ctx context.Context, instanceID, dimensionName string) (count int64, err error)
-	CloneRelationships(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string, ids []string) error
-	SetNumberOfChildren(ctx context.Context, attempt int, instanceID, dimensionName string) error
+	GetHierarchyNodeIDs(ctx context.Context, attempt int, instanceID, dimensionName string) (ids []string, err error)
+	// write
+	CreateInstanceHierarchyConstraints(ctx context.Context, attempt int, instanceID, dimensionName string) error
+	CloneNodes(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string) error
+	CloneNodesFromIDs(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string, ids []string, hasData bool) (err error)
+	CloneRelationships(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string) error
+	CloneRelationshipsFromIDs(ctx context.Context, attempt int, instanceID, dimensionName string, ids []string) error
+	SetNumberOfChildren(ctx context.Context, attempt int, instanceID, dimensionName string) (err error)
+	SetNumberOfChildrenFromIDs(ctx context.Context, attempt int, ids []string) (err error)
+	RemoveCloneEdges(ctx context.Context, attempt int, instanceID, dimensionName string) (err error)
+	RemoveCloneEdgesFromSourceIDs(ctx context.Context, attempt int, ids []string) (err error)
 	SetHasData(ctx context.Context, attempt int, instanceID, dimensionName string) error
 	MarkNodesToRemain(ctx context.Context, attempt int, instanceID, dimensionName string) error
 	RemoveNodesNotMarkedToRemain(ctx context.Context, attempt int, instanceID, dimensionName string) error
 	RemoveRemainMarker(ctx context.Context, attempt int, instanceID, dimensionName string) error
-
-	GetHierarchyCodelist(ctx context.Context, instanceID, dimension string) (string, error)
-	GetHierarchyRoot(ctx context.Context, instanceID, dimension string) (*models.HierarchyResponse, error)
-	GetHierarchyElement(ctx context.Context, instanceID, dimension, code string) (*models.HierarchyResponse, error)
 }
 
 // Observation defines functions to create and retrieve observation nodes

--- a/graph/driver/driver.go
+++ b/graph/driver/driver.go
@@ -33,20 +33,20 @@ type Hierarchy interface {
 	GetHierarchyRoot(ctx context.Context, instanceID, dimension string) (*models.HierarchyResponse, error)
 	GetHierarchyElement(ctx context.Context, instanceID, dimension, code string) (*models.HierarchyResponse, error)
 	GetCodesWithData(ctx context.Context, attempt int, instanceID, dimensionName string) (codes []string, err error)
-	GetGenericHierarchyNodeIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs []string, err error)
-	GetGenericHierarchyAncestriesIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs []string, err error)
+	GetGenericHierarchyNodeIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs map[string]struct{}, err error)
+	GetGenericHierarchyAncestriesIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs map[string]struct{}, err error)
 	CountNodes(ctx context.Context, instanceID, dimensionName string) (count int64, err error)
-	GetHierarchyNodeIDs(ctx context.Context, attempt int, instanceID, dimensionName string) (ids []string, err error)
+	GetHierarchyNodeIDs(ctx context.Context, attempt int, instanceID, dimensionName string) (ids map[string]struct{}, err error)
 	// write
 	CreateInstanceHierarchyConstraints(ctx context.Context, attempt int, instanceID, dimensionName string) error
 	CloneNodes(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string) error
-	CloneNodesFromIDs(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string, ids []string, hasData bool) (err error)
+	CloneNodesFromIDs(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string, ids map[string]struct{}, hasData bool) (err error)
 	CloneRelationships(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string) error
-	CloneRelationshipsFromIDs(ctx context.Context, attempt int, instanceID, dimensionName string, ids []string) error
+	CloneRelationshipsFromIDs(ctx context.Context, attempt int, instanceID, dimensionName string, ids map[string]struct{}) error
 	SetNumberOfChildren(ctx context.Context, attempt int, instanceID, dimensionName string) (err error)
-	SetNumberOfChildrenFromIDs(ctx context.Context, attempt int, ids []string) (err error)
+	SetNumberOfChildrenFromIDs(ctx context.Context, attempt int, ids map[string]struct{}) (err error)
 	RemoveCloneEdges(ctx context.Context, attempt int, instanceID, dimensionName string) (err error)
-	RemoveCloneEdgesFromSourceIDs(ctx context.Context, attempt int, ids []string) (err error)
+	RemoveCloneEdgesFromSourceIDs(ctx context.Context, attempt int, ids map[string]struct{}) (err error)
 	SetHasData(ctx context.Context, attempt int, instanceID, dimensionName string) error
 	MarkNodesToRemain(ctx context.Context, attempt int, instanceID, dimensionName string) error
 	RemoveNodesNotMarkedToRemain(ctx context.Context, attempt int, instanceID, dimensionName string) error

--- a/graph/driver/driver.go
+++ b/graph/driver/driver.go
@@ -29,9 +29,12 @@ type CodeList interface {
 // Hierarchy defines functions to create and retrieve generic and instance hierarchy nodes
 type Hierarchy interface {
 	CreateInstanceHierarchyConstraints(ctx context.Context, attempt int, instanceID, dimensionName string) error
-	CloneNodes(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string) error
+	GetCodesWithData(ctx context.Context, attempt int, instanceID, dimensionName string) (codes []string, err error)
+	GetGenericHierarchyNodeIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs []string, err error)
+	GetGenericHierarchyAncestriesIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs []string, err error)
+	CloneNodes(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string, ids []string, hasData bool) (err error)
 	CountNodes(ctx context.Context, instanceID, dimensionName string) (count int64, err error)
-	CloneRelationships(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string) error
+	CloneRelationships(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string, ids []string) error
 	SetNumberOfChildren(ctx context.Context, attempt int, instanceID, dimensionName string) error
 	SetHasData(ctx context.Context, attempt int, instanceID, dimensionName string) error
 	MarkNodesToRemain(ctx context.Context, attempt int, instanceID, dimensionName string) error

--- a/graph/driver/errors.go
+++ b/graph/driver/errors.go
@@ -12,6 +12,9 @@ var ErrNotFound = errors.New("not found")
 // more than one error, inside a call that requires exactly one.
 var ErrMultipleFound = errors.New("multiple found where should be one")
 
+// ErrNotImplemented is returned when a method is called but the driver does not implement it
+var ErrNotImplemented = errors.New("method not implemented by driver")
+
 // ErrAttemptsExceededLimit is returned when the number of attempts has reaced
 // the maximum permitted
 type ErrAttemptsExceededLimit struct {

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -53,6 +53,8 @@ func Test_New(t *testing.T) {
 }
 
 func Test_NewCodeListStore(t *testing.T) {
+	os.Setenv("GRAPH_DRIVER_TYPE", "mock")
+
 	Convey("Given only code list subset is requested", t, func() {
 		Convey("When NewCodeListStore is called", func() {
 			db, err := NewCodeListStore(context.Background())
@@ -88,6 +90,8 @@ func Test_NewCodeListStore(t *testing.T) {
 }
 
 func Test_NewHierarchyStore(t *testing.T) {
+	os.Setenv("GRAPH_DRIVER_TYPE", "mock")
+
 	Convey("Given only hierarchy subset is requested", t, func() {
 		Convey("When NewHierarchyStore is called", func() {
 			db, err := NewHierarchyStore(context.Background())
@@ -123,6 +127,8 @@ func Test_NewHierarchyStore(t *testing.T) {
 }
 
 func Test_NewInstanceStore(t *testing.T) {
+	os.Setenv("GRAPH_DRIVER_TYPE", "mock")
+
 	Convey("Given only instance subset is requested", t, func() {
 		Convey("When NewInstanceStore is called", func() {
 			db, err := NewInstanceStore(context.Background())
@@ -158,6 +164,8 @@ func Test_NewInstanceStore(t *testing.T) {
 }
 
 func Test_NewObservationStore(t *testing.T) {
+	os.Setenv("GRAPH_DRIVER_TYPE", "mock")
+
 	Convey("Given only observation subset is requested", t, func() {
 		Convey("When NewObservationStore is called", func() {
 			db, err := NewObservationStore(context.Background())
@@ -193,6 +201,8 @@ func Test_NewObservationStore(t *testing.T) {
 }
 
 func Test_NewDimensionStore(t *testing.T) {
+	os.Setenv("GRAPH_DRIVER_TYPE", "mock")
+
 	Convey("Given only dimension subset is requested", t, func() {
 		Convey("When NewDimensionStore is called", func() {
 			db, err := NewDimensionStore(context.Background())

--- a/mock/hierarchy.go
+++ b/mock/hierarchy.go
@@ -10,7 +10,23 @@ func (m *Mock) CreateInstanceHierarchyConstraints(ctx context.Context, attempt i
 	return m.checkForErrors()
 }
 
+func (m *Mock) GetCodesWithData(ctx context.Context, attempt int, instanceID, dimensionName string) (codes []string, err error) {
+	return []string{}, m.checkForErrors()
+}
+
+func (m *Mock) GetGenericHierarchyNodeIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs []string, err error) {
+	return []string{}, m.checkForErrors()
+}
+
+func (m *Mock) GetGenericHierarchyAncestriesIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs []string, err error) {
+	return []string{}, m.checkForErrors()
+}
+
 func (m *Mock) CloneNodes(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string) error {
+	return m.checkForErrors()
+}
+
+func (m *Mock) CloneNodesFromIDs(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string, ids []string, hasData bool) (err error) {
 	return m.checkForErrors()
 }
 
@@ -18,11 +34,31 @@ func (m *Mock) CountNodes(ctx context.Context, instanceID, dimensionName string)
 	return 0, m.checkForErrors()
 }
 
+func (m *Mock) GetHierarchyNodeIDs(ctx context.Context, attempt int, instanceID, dimensionName string) (ids []string, err error) {
+	return []string{}, m.checkForErrors()
+}
+
 func (m *Mock) CloneRelationships(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string) error {
 	return m.checkForErrors()
 }
 
+func (m *Mock) CloneRelationshipsFromIDs(ctx context.Context, attempt int, instanceID, dimensionName string, ids []string) error {
+	return m.checkForErrors()
+}
+
 func (m *Mock) SetNumberOfChildren(ctx context.Context, attempt int, instanceID, dimensionName string) error {
+	return m.checkForErrors()
+}
+
+func (m *Mock) SetNumberOfChildrenFromIDs(ctx context.Context, attempt int, ids []string) (err error) {
+	return m.checkForErrors()
+}
+
+func (m *Mock) RemoveCloneEdges(ctx context.Context, attempt int, instanceID, dimensionName string) (err error) {
+	return m.checkForErrors()
+}
+
+func (m *Mock) RemoveCloneEdgesFromSourceIDs(ctx context.Context, attempt int, ids []string) (err error) {
 	return m.checkForErrors()
 }
 

--- a/mock/hierarchy.go
+++ b/mock/hierarchy.go
@@ -14,19 +14,19 @@ func (m *Mock) GetCodesWithData(ctx context.Context, attempt int, instanceID, di
 	return []string{}, m.checkForErrors()
 }
 
-func (m *Mock) GetGenericHierarchyNodeIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs []string, err error) {
-	return []string{}, m.checkForErrors()
+func (m *Mock) GetGenericHierarchyNodeIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs map[string]struct{}, err error) {
+	return map[string]struct{}{}, m.checkForErrors()
 }
 
-func (m *Mock) GetGenericHierarchyAncestriesIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs []string, err error) {
-	return []string{}, m.checkForErrors()
+func (m *Mock) GetGenericHierarchyAncestriesIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs map[string]struct{}, err error) {
+	return map[string]struct{}{}, m.checkForErrors()
 }
 
 func (m *Mock) CloneNodes(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string) error {
 	return m.checkForErrors()
 }
 
-func (m *Mock) CloneNodesFromIDs(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string, ids []string, hasData bool) (err error) {
+func (m *Mock) CloneNodesFromIDs(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string, ids map[string]struct{}, hasData bool) (err error) {
 	return m.checkForErrors()
 }
 
@@ -34,15 +34,15 @@ func (m *Mock) CountNodes(ctx context.Context, instanceID, dimensionName string)
 	return 0, m.checkForErrors()
 }
 
-func (m *Mock) GetHierarchyNodeIDs(ctx context.Context, attempt int, instanceID, dimensionName string) (ids []string, err error) {
-	return []string{}, m.checkForErrors()
+func (m *Mock) GetHierarchyNodeIDs(ctx context.Context, attempt int, instanceID, dimensionName string) (ids map[string]struct{}, err error) {
+	return map[string]struct{}{}, m.checkForErrors()
 }
 
 func (m *Mock) CloneRelationships(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string) error {
 	return m.checkForErrors()
 }
 
-func (m *Mock) CloneRelationshipsFromIDs(ctx context.Context, attempt int, instanceID, dimensionName string, ids []string) error {
+func (m *Mock) CloneRelationshipsFromIDs(ctx context.Context, attempt int, instanceID, dimensionName string, ids map[string]struct{}) error {
 	return m.checkForErrors()
 }
 
@@ -50,7 +50,7 @@ func (m *Mock) SetNumberOfChildren(ctx context.Context, attempt int, instanceID,
 	return m.checkForErrors()
 }
 
-func (m *Mock) SetNumberOfChildrenFromIDs(ctx context.Context, attempt int, ids []string) (err error) {
+func (m *Mock) SetNumberOfChildrenFromIDs(ctx context.Context, attempt int, ids map[string]struct{}) (err error) {
 	return m.checkForErrors()
 }
 
@@ -58,7 +58,7 @@ func (m *Mock) RemoveCloneEdges(ctx context.Context, attempt int, instanceID, di
 	return m.checkForErrors()
 }
 
-func (m *Mock) RemoveCloneEdgesFromSourceIDs(ctx context.Context, attempt int, ids []string) (err error) {
+func (m *Mock) RemoveCloneEdgesFromSourceIDs(ctx context.Context, attempt int, ids map[string]struct{}) (err error) {
 	return m.checkForErrors()
 }
 

--- a/neo4j/hierarchy_reader.go
+++ b/neo4j/hierarchy_reader.go
@@ -101,6 +101,25 @@ func (n *Neo4j) queryElements(ctx context.Context, instanceID, dimension, neoStm
 	return res.List, nil
 }
 
+// CountNodes returns the number of nodes existing in the specified instance hierarchy
+func (n *Neo4j) CountNodes(ctx context.Context, instanceID, dimensionName string) (count int64, err error) {
+	q := fmt.Sprintf(
+		query.CountHierarchyNodes,
+		instanceID,
+		dimensionName,
+	)
+
+	logData := log.Data{
+		"instance_id":    instanceID,
+		"dimension_name": dimensionName,
+		"query":          q,
+	}
+
+	log.Event(ctx, "counting nodes in the new instance hierarchy", log.INFO, logData)
+
+	return n.Count(q)
+}
+
 // GetCodesWithData not implemented by Neo4j (new hierarchy build algorithm)
 func (n *Neo4j) GetCodesWithData(ctx context.Context, attempt int, instanceID, dimensionName string) (codes []string, err error) {
 	return []string{}, driver.ErrNotImplemented
@@ -113,5 +132,10 @@ func (n *Neo4j) GetGenericHierarchyNodeIDs(ctx context.Context, attempt int, cod
 
 // GetGenericHierarchyAncestriesIDs not implemented by Neo4j (new hierarchy build algorithm)
 func (n *Neo4j) GetGenericHierarchyAncestriesIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs []string, err error) {
+	return []string{}, driver.ErrNotImplemented
+}
+
+// GetHierarchyNodeIDs not implemented by Neo4j (new hierarchy build algorithm)
+func (n *Neo4j) GetHierarchyNodeIDs(ctx context.Context, attempt int, instanceID, dimensionName string) (ids []string, err error) {
 	return []string{}, driver.ErrNotImplemented
 }

--- a/neo4j/hierarchy_reader.go
+++ b/neo4j/hierarchy_reader.go
@@ -100,3 +100,18 @@ func (n *Neo4j) queryElements(ctx context.Context, instanceID, dimension, neoStm
 
 	return res.List, nil
 }
+
+// GetCodesWithData not implemented by Neo4j (new hierarchy build algorithm)
+func (n *Neo4j) GetCodesWithData(ctx context.Context, attempt int, instanceID, dimensionName string) (codes []string, err error) {
+	return []string{}, driver.ErrNotImplemented
+}
+
+// GetGenericHierarchyNodeIDs not implemented by Neo4j (new hierarchy build algorithm)
+func (n *Neo4j) GetGenericHierarchyNodeIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs []string, err error) {
+	return []string{}, driver.ErrNotImplemented
+}
+
+// GetGenericHierarchyAncestriesIDs not implemented by Neo4j (new hierarchy build algorithm)
+func (n *Neo4j) GetGenericHierarchyAncestriesIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs []string, err error) {
+	return []string{}, driver.ErrNotImplemented
+}

--- a/neo4j/hierarchy_reader.go
+++ b/neo4j/hierarchy_reader.go
@@ -126,16 +126,16 @@ func (n *Neo4j) GetCodesWithData(ctx context.Context, attempt int, instanceID, d
 }
 
 // GetGenericHierarchyNodeIDs not implemented by Neo4j (new hierarchy build algorithm)
-func (n *Neo4j) GetGenericHierarchyNodeIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs []string, err error) {
-	return []string{}, driver.ErrNotImplemented
+func (n *Neo4j) GetGenericHierarchyNodeIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs map[string]struct{}, err error) {
+	return map[string]struct{}{}, driver.ErrNotImplemented
 }
 
 // GetGenericHierarchyAncestriesIDs not implemented by Neo4j (new hierarchy build algorithm)
-func (n *Neo4j) GetGenericHierarchyAncestriesIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs []string, err error) {
-	return []string{}, driver.ErrNotImplemented
+func (n *Neo4j) GetGenericHierarchyAncestriesIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs map[string]struct{}, err error) {
+	return map[string]struct{}{}, driver.ErrNotImplemented
 }
 
 // GetHierarchyNodeIDs not implemented by Neo4j (new hierarchy build algorithm)
-func (n *Neo4j) GetHierarchyNodeIDs(ctx context.Context, attempt int, instanceID, dimensionName string) (ids []string, err error) {
-	return []string{}, driver.ErrNotImplemented
+func (n *Neo4j) GetHierarchyNodeIDs(ctx context.Context, attempt int, instanceID, dimensionName string) (ids map[string]struct{}, err error) {
+	return map[string]struct{}{}, driver.ErrNotImplemented
 }

--- a/neo4j/hierarchy_test.go
+++ b/neo4j/hierarchy_test.go
@@ -127,7 +127,7 @@ func TestStore_CloneNodes(t *testing.T) {
 		db := &Neo4j{driver, 5, 30}
 
 		Convey("When CloneNodes is called", func() {
-			err := db.CloneNodes(context.Background(), 1, instanceID, codeListID, dimensionName, []string{}, false)
+			err := db.CloneNodes(context.Background(), 1, instanceID, codeListID, dimensionName)
 
 			Convey("Then the returned error should be nil", func() {
 				So(err, ShouldBeNil)
@@ -136,18 +136,6 @@ func TestStore_CloneNodes(t *testing.T) {
 			Convey("Then db.Exec should be called once for the expected query", func() {
 				So(len(driver.ExecCalls()), ShouldEqual, 1)
 				So(driver.ExecCalls()[0].Query, ShouldEqual, expectedQuery)
-			})
-		})
-
-		Convey("When CloneNode is called with a list of IDs", func() {
-			err := db.CloneNodes(context.Background(), 1, instanceID, codeListID, dimensionName, []string{"someID"}, false)
-
-			Convey("Then the returned error should be ErrNotImplemented", func() {
-				So(err, ShouldEqual, graph.ErrNotImplemented)
-			})
-
-			Convey("Then db.Exec is not called", func() {
-				So(len(driver.ExecCalls()), ShouldEqual, 0)
 			})
 		})
 	})
@@ -165,7 +153,7 @@ func TestStore_CloneNodes_NeoerrExec(t *testing.T) {
 		db := &Neo4j{driver, 5, 30}
 
 		Convey("When CloneNodes is called", func() {
-			err := db.CloneNodes(context.Background(), 1, instanceID, codeListID, dimensionName, []string{}, false)
+			err := db.CloneNodes(context.Background(), 1, instanceID, codeListID, dimensionName)
 
 			Convey("Then db.Exec should be called once for the expected query", func() {
 				So(len(driver.ExecCalls()), ShouldEqual, 1)
@@ -204,7 +192,7 @@ func TestStore_CloneRelationships(t *testing.T) {
 		db := &Neo4j{driver, 5, 30}
 
 		Convey("When CloneRelationships is called", func() {
-			err := db.CloneRelationships(context.Background(), 1, instanceID, codeListID, dimensionName, []string{})
+			err := db.CloneRelationships(context.Background(), 1, instanceID, codeListID, dimensionName)
 
 			Convey("Then the returned error should be nil", func() {
 				So(err, ShouldBeNil)
@@ -213,18 +201,6 @@ func TestStore_CloneRelationships(t *testing.T) {
 			Convey("Then db.Exec should be called once for the expected query", func() {
 				So(len(driver.ExecCalls()), ShouldEqual, 1)
 				So(driver.ExecCalls()[0].Query, ShouldEqual, expectedQuery)
-			})
-		})
-
-		Convey("When CloneNode is called with a list of IDs", func() {
-			err := db.CloneRelationships(context.Background(), 1, instanceID, codeListID, dimensionName, []string{"someID"})
-
-			Convey("Then the returned error should be ErrNotImplemented", func() {
-				So(err, ShouldEqual, graph.ErrNotImplemented)
-			})
-
-			Convey("Then db.Exec is not called", func() {
-				So(len(driver.ExecCalls()), ShouldEqual, 0)
 			})
 		})
 	})
@@ -243,7 +219,7 @@ func TestStore_CloneRelationships_NeoErrExec(t *testing.T) {
 
 		Convey("When cloneRelationships is called", func() {
 
-			err := db.CloneRelationships(context.Background(), 1, instanceID, codeListID, dimensionName, []string{})
+			err := db.CloneRelationships(context.Background(), 1, instanceID, codeListID, dimensionName)
 
 			Convey("Then db.Exec should be called once for the expected query", func() {
 				So(len(driver.ExecCalls()), ShouldEqual, 1)

--- a/neo4j/hierarchy_test.go
+++ b/neo4j/hierarchy_test.go
@@ -127,7 +127,7 @@ func TestStore_CloneNodes(t *testing.T) {
 		db := &Neo4j{driver, 5, 30}
 
 		Convey("When CloneNodes is called", func() {
-			err := db.CloneNodes(context.Background(), 1, instanceID, codeListID, dimensionName)
+			err := db.CloneNodes(context.Background(), 1, instanceID, codeListID, dimensionName, []string{}, false)
 
 			Convey("Then the returned error should be nil", func() {
 				So(err, ShouldBeNil)
@@ -136,6 +136,18 @@ func TestStore_CloneNodes(t *testing.T) {
 			Convey("Then db.Exec should be called once for the expected query", func() {
 				So(len(driver.ExecCalls()), ShouldEqual, 1)
 				So(driver.ExecCalls()[0].Query, ShouldEqual, expectedQuery)
+			})
+		})
+
+		Convey("When CloneNode is called with a list of IDs", func() {
+			err := db.CloneNodes(context.Background(), 1, instanceID, codeListID, dimensionName, []string{"someID"}, false)
+
+			Convey("Then the returned error should be ErrNotImplemented", func() {
+				So(err, ShouldEqual, graph.ErrNotImplemented)
+			})
+
+			Convey("Then db.Exec is not called", func() {
+				So(len(driver.ExecCalls()), ShouldEqual, 0)
 			})
 		})
 	})
@@ -153,7 +165,7 @@ func TestStore_CloneNodes_NeoerrExec(t *testing.T) {
 		db := &Neo4j{driver, 5, 30}
 
 		Convey("When CloneNodes is called", func() {
-			err := db.CloneNodes(context.Background(), 1, instanceID, codeListID, dimensionName)
+			err := db.CloneNodes(context.Background(), 1, instanceID, codeListID, dimensionName, []string{}, false)
 
 			Convey("Then db.Exec should be called once for the expected query", func() {
 				So(len(driver.ExecCalls()), ShouldEqual, 1)
@@ -192,7 +204,7 @@ func TestStore_CloneRelationships(t *testing.T) {
 		db := &Neo4j{driver, 5, 30}
 
 		Convey("When CloneRelationships is called", func() {
-			err := db.CloneRelationships(context.Background(), 1, instanceID, codeListID, dimensionName)
+			err := db.CloneRelationships(context.Background(), 1, instanceID, codeListID, dimensionName, []string{})
 
 			Convey("Then the returned error should be nil", func() {
 				So(err, ShouldBeNil)
@@ -201,6 +213,18 @@ func TestStore_CloneRelationships(t *testing.T) {
 			Convey("Then db.Exec should be called once for the expected query", func() {
 				So(len(driver.ExecCalls()), ShouldEqual, 1)
 				So(driver.ExecCalls()[0].Query, ShouldEqual, expectedQuery)
+			})
+		})
+
+		Convey("When CloneNode is called with a list of IDs", func() {
+			err := db.CloneRelationships(context.Background(), 1, instanceID, codeListID, dimensionName, []string{"someID"})
+
+			Convey("Then the returned error should be ErrNotImplemented", func() {
+				So(err, ShouldEqual, graph.ErrNotImplemented)
+			})
+
+			Convey("Then db.Exec is not called", func() {
+				So(len(driver.ExecCalls()), ShouldEqual, 0)
 			})
 		})
 	})
@@ -219,7 +243,7 @@ func TestStore_CloneRelationships_NeoErrExec(t *testing.T) {
 
 		Convey("When cloneRelationships is called", func() {
 
-			err := db.CloneRelationships(context.Background(), 1, instanceID, codeListID, dimensionName)
+			err := db.CloneRelationships(context.Background(), 1, instanceID, codeListID, dimensionName, []string{})
 
 			Convey("Then db.Exec should be called once for the expected query", func() {
 				So(len(driver.ExecCalls()), ShouldEqual, 1)

--- a/neo4j/hierarchy_writer.go
+++ b/neo4j/hierarchy_writer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ONSdigital/dp-graph/v2/graph/driver"
 	"github.com/ONSdigital/dp-graph/v2/neo4j/query"
 	"github.com/ONSdigital/log.go/log"
 )
@@ -36,7 +37,13 @@ func (n *Neo4j) CreateInstanceHierarchyConstraints(ctx context.Context, attempt 
 }
 
 // CloneNodes copies nodes from a generic hierarchy and identifies them as instance specific hierarchy nodes
-func (n *Neo4j) CloneNodes(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string) error {
+func (n *Neo4j) CloneNodes(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string, ids []string, hasData bool) error {
+
+	// array of IDs are provided by the new hierarchy build algorithm, which is not implemented by Neo4j
+	if len(ids) > 0 {
+		return driver.ErrNotImplemented
+	}
+
 	q := fmt.Sprintf(
 		query.CloneHierarchyNodes,
 		codeListID,
@@ -58,7 +65,7 @@ func (n *Neo4j) CloneNodes(ctx context.Context, attempt int, instanceID, codeLis
 			return finalErr
 		}
 
-		return n.CloneNodes(ctx, attempt+1, instanceID, codeListID, dimensionName)
+		return n.CloneNodes(ctx, attempt+1, instanceID, codeListID, dimensionName, ids, hasData)
 	}
 
 	return nil
@@ -84,7 +91,13 @@ func (n *Neo4j) CountNodes(ctx context.Context, instanceID, dimensionName string
 }
 
 // CloneRelationships copies relationships from a generic hierarchy and uses them to join instance specific hierarchy nodes
-func (n *Neo4j) CloneRelationships(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string) error {
+func (n *Neo4j) CloneRelationships(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string, ids []string) error {
+
+	// array of IDs are provided by the new hierarchy build algorithm, which is not implemented by Neo4j
+	if len(ids) > 0 {
+		return driver.ErrNotImplemented
+	}
+
 	q := fmt.Sprintf(
 		query.CloneHierarchyRelationships,
 		codeListID,
@@ -109,7 +122,7 @@ func (n *Neo4j) CloneRelationships(ctx context.Context, attempt int, instanceID,
 			return finalErr
 		}
 
-		return n.CloneRelationships(ctx, attempt+1, instanceID, codeListID, dimensionName)
+		return n.CloneRelationships(ctx, attempt+1, instanceID, codeListID, dimensionName, ids)
 	}
 
 	return nil

--- a/neo4j/hierarchy_writer.go
+++ b/neo4j/hierarchy_writer.go
@@ -239,11 +239,11 @@ func (n *Neo4j) RemoveRemainMarker(ctx context.Context, attempt int, instanceID,
 	return nil
 }
 
-func (n *Neo4j) CloneNodesFromIDs(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string, ids []string, hasData bool) (err error) {
+func (n *Neo4j) CloneNodesFromIDs(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string, ids map[string]struct{}, hasData bool) (err error) {
 	return driver.ErrNotImplemented
 }
 
-func (n *Neo4j) CloneRelationshipsFromIDs(ctx context.Context, attempt int, instanceID, dimensionName string, ids []string) error {
+func (n *Neo4j) CloneRelationshipsFromIDs(ctx context.Context, attempt int, instanceID, dimensionName string, ids map[string]struct{}) error {
 	return driver.ErrNotImplemented
 }
 
@@ -251,10 +251,10 @@ func (n *Neo4j) RemoveCloneEdges(ctx context.Context, attempt int, instanceID, d
 	return driver.ErrNotImplemented
 }
 
-func (n *Neo4j) RemoveCloneEdgesFromSourceIDs(ctx context.Context, attempt int, ids []string) (err error) {
+func (n *Neo4j) RemoveCloneEdgesFromSourceIDs(ctx context.Context, attempt int, ids map[string]struct{}) (err error) {
 	return driver.ErrNotImplemented
 }
 
-func (n *Neo4j) SetNumberOfChildrenFromIDs(ctx context.Context, attempt int, ids []string) (err error) {
+func (n *Neo4j) SetNumberOfChildrenFromIDs(ctx context.Context, attempt int, ids map[string]struct{}) (err error) {
 	return driver.ErrNotImplemented
 }

--- a/neo4j/hierarchy_writer.go
+++ b/neo4j/hierarchy_writer.go
@@ -100,7 +100,6 @@ func (n *Neo4j) CloneRelationships(ctx context.Context, attempt int, instanceID,
 // SetNumberOfChildren traverses the instance hierarchy, counts the number of nodes
 // with incoming hasParent relationships and sets that number on the node as a property
 func (n *Neo4j) SetNumberOfChildren(ctx context.Context, attempt int, instanceID, dimensionName string) error {
-
 	q := fmt.Sprintf(
 		query.SetNumberOfChildren,
 		instanceID,

--- a/neo4j/hierarchy_writer.go
+++ b/neo4j/hierarchy_writer.go
@@ -37,13 +37,7 @@ func (n *Neo4j) CreateInstanceHierarchyConstraints(ctx context.Context, attempt 
 }
 
 // CloneNodes copies nodes from a generic hierarchy and identifies them as instance specific hierarchy nodes
-func (n *Neo4j) CloneNodes(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string, ids []string, hasData bool) error {
-
-	// array of IDs are provided by the new hierarchy build algorithm, which is not implemented by Neo4j
-	if len(ids) > 0 {
-		return driver.ErrNotImplemented
-	}
-
+func (n *Neo4j) CloneNodes(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string) error {
 	q := fmt.Sprintf(
 		query.CloneHierarchyNodes,
 		codeListID,
@@ -65,39 +59,14 @@ func (n *Neo4j) CloneNodes(ctx context.Context, attempt int, instanceID, codeLis
 			return finalErr
 		}
 
-		return n.CloneNodes(ctx, attempt+1, instanceID, codeListID, dimensionName, ids, hasData)
+		return n.CloneNodes(ctx, attempt+1, instanceID, codeListID, dimensionName)
 	}
 
 	return nil
 }
 
-// CountNodes returns the number of nodes existing in the specified instance hierarchy
-func (n *Neo4j) CountNodes(ctx context.Context, instanceID, dimensionName string) (count int64, err error) {
-	q := fmt.Sprintf(
-		query.CountHierarchyNodes,
-		instanceID,
-		dimensionName,
-	)
-
-	logData := log.Data{
-		"instance_id":    instanceID,
-		"dimension_name": dimensionName,
-		"query":          q,
-	}
-
-	log.Event(ctx, "counting nodes in the new instance hierarchy", log.INFO, logData)
-
-	return n.Count(q)
-}
-
 // CloneRelationships copies relationships from a generic hierarchy and uses them to join instance specific hierarchy nodes
-func (n *Neo4j) CloneRelationships(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string, ids []string) error {
-
-	// array of IDs are provided by the new hierarchy build algorithm, which is not implemented by Neo4j
-	if len(ids) > 0 {
-		return driver.ErrNotImplemented
-	}
-
+func (n *Neo4j) CloneRelationships(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string) error {
 	q := fmt.Sprintf(
 		query.CloneHierarchyRelationships,
 		codeListID,
@@ -122,7 +91,7 @@ func (n *Neo4j) CloneRelationships(ctx context.Context, attempt int, instanceID,
 			return finalErr
 		}
 
-		return n.CloneRelationships(ctx, attempt+1, instanceID, codeListID, dimensionName, ids)
+		return n.CloneRelationships(ctx, attempt+1, instanceID, codeListID, dimensionName)
 	}
 
 	return nil
@@ -131,6 +100,7 @@ func (n *Neo4j) CloneRelationships(ctx context.Context, attempt int, instanceID,
 // SetNumberOfChildren traverses the instance hierarchy, counts the number of nodes
 // with incoming hasParent relationships and sets that number on the node as a property
 func (n *Neo4j) SetNumberOfChildren(ctx context.Context, attempt int, instanceID, dimensionName string) error {
+
 	q := fmt.Sprintf(
 		query.SetNumberOfChildren,
 		instanceID,
@@ -268,4 +238,24 @@ func (n *Neo4j) RemoveRemainMarker(ctx context.Context, attempt int, instanceID,
 	}
 
 	return nil
+}
+
+func (n *Neo4j) CloneNodesFromIDs(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string, ids []string, hasData bool) (err error) {
+	return driver.ErrNotImplemented
+}
+
+func (n *Neo4j) CloneRelationshipsFromIDs(ctx context.Context, attempt int, instanceID, dimensionName string, ids []string) error {
+	return driver.ErrNotImplemented
+}
+
+func (n *Neo4j) RemoveCloneEdges(ctx context.Context, attempt int, instanceID, dimensionName string) (err error) {
+	return driver.ErrNotImplemented
+}
+
+func (n *Neo4j) RemoveCloneEdgesFromSourceIDs(ctx context.Context, attempt int, ids []string) (err error) {
+	return driver.ErrNotImplemented
+}
+
+func (n *Neo4j) SetNumberOfChildrenFromIDs(ctx context.Context, attempt int, ids []string) (err error) {
+	return driver.ErrNotImplemented
 }

--- a/neptune/driver/driver.go
+++ b/neptune/driver/driver.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"context"
+
 	"github.com/ONSdigital/dp-graph/v2/graph/driver"
 
 	gremgo "github.com/ONSdigital/gremgo-neptune"

--- a/neptune/hierarchy.go
+++ b/neptune/hierarchy.go
@@ -65,7 +65,7 @@ func (n *NeptuneDB) doGetGenericHierarchyNodeIDs(ctx context.Context, attempt in
 	}
 
 	processBatch := func(chunkCodes []string) (ret []string, err error) {
-		codesString := `["` + strings.Join(chunkCodes, `","`) + `"]`
+		codesString := `['` + strings.Join(chunkCodes, `','`) + `']`
 		var stmt string
 		if ancestries {
 			stmt = fmt.Sprintf(
@@ -390,7 +390,7 @@ func (n *NeptuneDB) SetHasData(ctx context.Context, attempt int, instanceID, dim
 		return errors.Wrapf(err, "Gremlin query failed: %q", codesWithDataStmt)
 	}
 
-	codesString := `["` + strings.Join(codes, `","`) + `"]`
+	codesString := `['` + strings.Join(codes, `','`) + `']`
 
 	gremStmt := fmt.Sprintf(
 		query.SetHasData,

--- a/neptune/hierarchy_test.go
+++ b/neptune/hierarchy_test.go
@@ -73,7 +73,7 @@ func TestNeptuneDB_GetGenericHierarchyNodeIDs(t *testing.T) {
 		}
 		db := mockDB(poolMock)
 
-		Convey("When GetGenericHierarchyNodeIDs is called", func() {
+		Convey("When GetGenericHierarchyNodeIDs is called with a list of codes", func() {
 			ids, err := db.GetGenericHierarchyNodeIDs(ctx, testAttempt, testCodeListID, testCodes)
 
 			Convey("Then no error is returned", func() {
@@ -90,6 +90,19 @@ func TestNeptuneDB_GetGenericHierarchyNodeIDs(t *testing.T) {
 				So(poolMock.GetStringListCalls()[0].Query, ShouldBeIn, []string{expectedQueryOp1, expectedQueryOp2})
 			})
 		})
+
+		Convey("When GetGenericHierarchyNodeIDs is called with an empty list of codes", func() {
+			ids, err := db.GetGenericHierarchyNodeIDs(ctx, testAttempt, testCodeListID, []string{})
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Then an empty map of IDs is returned and no query is executed", func() {
+				So(ids, ShouldResemble, map[string]struct{}{})
+				So(len(poolMock.GetStringListCalls()), ShouldEqual, 0)
+			})
+		})
 	})
 }
 
@@ -101,7 +114,7 @@ func TestNeptuneDB_GetGenericHierarchyAncestriesIDs(t *testing.T) {
 		}
 		db := mockDB(poolMock)
 
-		Convey("When GetGenericHierarchyAncestriesIDs is called", func() {
+		Convey("When GetGenericHierarchyAncestriesIDs is called with a list of codes", func() {
 			ids, err := db.GetGenericHierarchyAncestriesIDs(ctx, testAttempt, testCodeListID, testCodes)
 
 			Convey("Then no error is returned", func() {
@@ -119,6 +132,19 @@ func TestNeptuneDB_GetGenericHierarchyAncestriesIDs(t *testing.T) {
 				So(poolMock.GetStringListCalls()[0].Query, ShouldBeIn, []string{expectedQueryOp1, expectedQueryOp2})
 			})
 		})
+
+		Convey("When GetGenericHierarchyAncestriesIDs is called with an empty list of codes", func() {
+			ids, err := db.GetGenericHierarchyAncestriesIDs(ctx, testAttempt, testCodeListID, []string{})
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Then an empty map of IDs is returned and no query is executed", func() {
+				So(ids, ShouldResemble, map[string]struct{}{})
+				So(len(poolMock.GetStringListCalls()), ShouldEqual, 0)
+			})
+		})
 	})
 }
 
@@ -132,7 +158,7 @@ func TestNeptuneDB_CloneNodesFromID(t *testing.T) {
 		}
 		db := mockDB(poolMock)
 
-		Convey("When CloneNodes is called", func() {
+		Convey("When CloneNodes is called with a map of IDs", func() {
 			err := db.CloneNodesFromIDs(ctx, testAttempt, testInstanceID, testCodeListID, testDimensionName, testIds, true)
 
 			Convey("Then no error is returned", func() {
@@ -151,6 +177,18 @@ func TestNeptuneDB_CloneNodesFromID(t *testing.T) {
 				expectedQueryOp2 := fmt.Sprintf(expectedQueryFmt, "cpih1dim1aggid--cpih1dim1S90402", "cpih1dim1aggid--cpih1dim1S90401")
 				So(len(poolMock.ExecuteCalls()), ShouldEqual, 1)
 				So(poolMock.ExecuteCalls()[0].Query, ShouldBeIn, []string{expectedQueryOp1, expectedQueryOp2})
+			})
+		})
+
+		Convey("When CloneNodes is called with an empty map of IDs", func() {
+			err := db.CloneNodesFromIDs(ctx, testAttempt, testInstanceID, testCodeListID, testDimensionName, map[string]struct{}{}, true)
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Then no query is executed", func() {
+				So(len(poolMock.ExecuteCalls()), ShouldEqual, 0)
 			})
 		})
 	})
@@ -194,7 +232,7 @@ func TestNeptuneDB_CloneRelationshipsFromIDs(t *testing.T) {
 		}
 		db := mockDB(poolMock)
 
-		Convey("When CloneRelationShips is called with unique IDs", func() {
+		Convey("When CloneRelationShips is called with a map of IDs", func() {
 			err := db.CloneRelationshipsFromIDs(ctx, testAttempt, testInstanceID, testDimensionName, testAllIds)
 
 			Convey("Then no error is returned", func() {
@@ -216,6 +254,18 @@ func TestNeptuneDB_CloneRelationshipsFromIDs(t *testing.T) {
 				So(strings.Count(poolMock.GetECalls()[0].Q, "'cpih1dim1aggid--cpih1dim1T90000'"), ShouldEqual, 1)
 				So(strings.Count(poolMock.GetECalls()[0].Q, "'cpih1dim1aggid--cpih1dim1A0'"), ShouldEqual, 1)
 				So(strings.HasSuffix(poolMock.GetECalls()[0].Q, expectedQSuffix), ShouldBeTrue)
+			})
+		})
+
+		Convey("When CloneRelationShips is called with an empty map of IDs", func() {
+			err := db.CloneRelationshipsFromIDs(ctx, testAttempt, testInstanceID, testDimensionName, map[string]struct{}{})
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Then no query is executed", func() {
+				So(len(poolMock.GetECalls()), ShouldEqual, 0)
 			})
 		})
 	})
@@ -257,7 +307,7 @@ func TestNeptuneDB_RemoveCloneEdgesFromSourceIDs(t *testing.T) {
 		}
 		db := mockDB(poolMock)
 
-		Convey("When RemoveCloneEdgesFromSourceIDs is called", func() {
+		Convey("When RemoveCloneEdgesFromSourceIDs is called with a map of IDs", func() {
 			err := db.RemoveCloneEdgesFromSourceIDs(ctx, testAttempt, testClonedIds)
 
 			Convey("Then no error is returned", func() {
@@ -273,6 +323,18 @@ func TestNeptuneDB_RemoveCloneEdgesFromSourceIDs(t *testing.T) {
 					So(strings.Count(poolMock.ExecuteCalls()[0].Query, id), ShouldEqual, 1)
 				}
 				So(strings.HasSuffix(poolMock.ExecuteCalls()[0].Query, expectedQSuffix), ShouldBeTrue)
+			})
+		})
+
+		Convey("When RemoveCloneEdgesFromSourceIDs is called with an empty map of IDs", func() {
+			err := db.RemoveCloneEdgesFromSourceIDs(ctx, testAttempt, map[string]struct{}{})
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Then no query is executed", func() {
+				So(len(poolMock.ExecuteCalls()), ShouldEqual, 0)
 			})
 		})
 	})
@@ -339,7 +401,7 @@ func TestNeptuneDB_SetNumberOfChildrenFromIDs(t *testing.T) {
 		}
 		db := mockDB(poolMock)
 
-		Convey("When SetNumberOfChildrenFromIDs is called", func() {
+		Convey("When SetNumberOfChildrenFromIDs is called with a map of IDs", func() {
 			err := db.SetNumberOfChildrenFromIDs(ctx, testAttempt, testClonedIds)
 
 			Convey("Then no error is returned", func() {
@@ -355,6 +417,18 @@ func TestNeptuneDB_SetNumberOfChildrenFromIDs(t *testing.T) {
 					So(strings.Count(poolMock.ExecuteCalls()[0].Query, id), ShouldEqual, 1)
 				}
 				So(strings.HasSuffix(poolMock.ExecuteCalls()[0].Query, expectedQSuffix), ShouldBeTrue)
+			})
+		})
+
+		Convey("When SetNumberOfChildrenFromIDs is called with an empty map of IDs", func() {
+			err := db.SetNumberOfChildrenFromIDs(ctx, testAttempt, map[string]struct{}{})
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Then no query is executed", func() {
+				So(len(poolMock.ExecuteCalls()), ShouldEqual, 0)
 			})
 		})
 	})

--- a/neptune/hierarchy_test.go
+++ b/neptune/hierarchy_test.go
@@ -190,8 +190,8 @@ func TestNeptuneDB_CloneRelationshipsFromIDs(t *testing.T) {
 		}
 		db := mockDB(poolMock)
 
-		Convey("When CloneRelationShips is called with duplicated IDs", func() {
-			err := db.CloneRelationshipsFromIDs(ctx, testAttempt, testInstanceID, testDimensionName, testAllIds)
+		Convey("When CloneRelationShips is called with unique IDs", func() {
+			err := db.CloneRelationshipsFromIDs(ctx, testAttempt, testInstanceID, testDimensionName, unique(testAllIds))
 
 			Convey("Then no error is returned", func() {
 				So(err, ShouldBeNil)

--- a/neptune/hierarchy_test.go
+++ b/neptune/hierarchy_test.go
@@ -122,7 +122,7 @@ func TestNeptuneDB_GetGenericHierarchyAncestriesIDs(t *testing.T) {
 	})
 }
 
-func TestNeptuneDB_CloneNodes(t *testing.T) {
+func TestNeptuneDB_CloneNodesFromID(t *testing.T) {
 
 	Convey("Given a mocked neptune DB", t, func() {
 		poolMock := &internal.NeptunePoolMock{

--- a/neptune/hierarchy_test.go
+++ b/neptune/hierarchy_test.go
@@ -2,12 +2,265 @@ package neptune
 
 import (
 	"context"
-	"github.com/ONSdigital/dp-graph/v2/neptune/internal"
-	"github.com/ONSdigital/gremgo-neptune"
+	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/ONSdigital/dp-graph/v2/neptune/internal"
+	"github.com/ONSdigital/graphson"
+	"github.com/ONSdigital/gremgo-neptune"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
+
+var (
+	ctx               = context.Background()
+	testCodeListID    = "cpih1dim1aggid"
+	testInstanceID    = "f0a2f3f2-cc86-4bbb-a549-ffc99c89292c"
+	testDimensionName = "aggregate"
+	testAttempt       = 1
+	testCodes         = []string{"cpih1dim1S90401", "cpih1dim1S90402"}
+	testIds           = []string{"cpih1dim1aggid--cpih1dim1S90401", "cpih1dim1aggid--cpih1dim1S90402"}
+	testAllIds        = []string{"cpih1dim1aggid--cpih1dim1S90401", "cpih1dim1aggid--cpih1dim1S90402",
+		"cpih1dim1aggid--cpih1dim1G90400", "cpih1dim1aggid--cpih1dim1G90400",
+		"cpih1dim1aggid--cpih1dim1T90000", "cpih1dim1aggid--cpih1dim1T90000",
+		"cpih1dim1aggid--cpih1dim1A0", "cpih1dim1aggid--cpih1dim1A0"}
+)
+
+func TestNeptuneDB_GetCodesWithData(t *testing.T) {
+
+	Convey("Given a mocked neptune DB that returns a code list", t, func() {
+		poolMock := &internal.NeptunePoolMock{
+			GetStringListFunc: internal.ReturnCodesList,
+		}
+		db := mockDB(poolMock)
+
+		Convey("When GetCodesWithData is called", func() {
+			codes, err := db.GetCodesWithData(ctx, testAttempt, testInstanceID, testDimensionName)
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Then the expected list of codes is returned", func() {
+				So(len(codes), ShouldEqual, 2)
+				So(codes, ShouldContain, "cpih1dim1S90401")
+				So(codes, ShouldContain, "cpih1dim1S90402")
+				expectedQuery := `g.V().hasLabel('_f0a2f3f2-cc86-4bbb-a549-ffc99c89292c_aggregate').values('value')`
+				So(len(poolMock.GetStringListCalls()), ShouldEqual, 1)
+				So(poolMock.GetStringListCalls()[0].Query, ShouldEqual, expectedQuery)
+			})
+		})
+	})
+}
+
+func TestNeptuneDB_GetGenericHierarchyNodeIDs(t *testing.T) {
+
+	Convey("Given a mocked neptune DB that returns a list of generic hierarchy node IDs (leaves)", t, func() {
+		poolMock := &internal.NeptunePoolMock{
+			GetStringListFunc: internal.ReturnGenericHierarchyLeavesIDs,
+		}
+		db := mockDB(poolMock)
+
+		Convey("When GetGenericHierarchyNodeIDs is called", func() {
+			ids, err := db.GetGenericHierarchyNodeIDs(ctx, testAttempt, testCodeListID, testCodes)
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Then the expected list of IDs is returned and the expected query is executed, in any order of IDs", func() {
+				So(len(ids), ShouldEqual, 2)
+				So(ids, ShouldContain, "cpih1dim1aggid--cpih1dim1S90401")
+				So(ids, ShouldContain, "cpih1dim1aggid--cpih1dim1S90402")
+				expectedQueryOp1 := `g.V().hasLabel('_generic_hierarchy_node_cpih1dim1aggid').has('code',within(["cpih1dim1S90401","cpih1dim1S90402"])).id()`
+				expectedQueryOp2 := `g.V().hasLabel('_generic_hierarchy_node_cpih1dim1aggid').has('code',within(["cpih1dim1S90402","cpih1dim1S90401"])).id()`
+				So(len(poolMock.GetStringListCalls()), ShouldEqual, 1)
+				So(poolMock.GetStringListCalls()[0].Query, ShouldBeIn, []string{expectedQueryOp1, expectedQueryOp2})
+			})
+		})
+	})
+}
+
+func TestNeptuneDB_GetGenericHierarchyAncestriesIDs(t *testing.T) {
+
+	Convey("Given a mocked neptune DB that returns a list of generic ancestry hierarchy node IDs, with duplicates", t, func() {
+		poolMock := &internal.NeptunePoolMock{
+			GetStringListFunc: internal.ReturnGenericHierarchyAncestryIDs,
+		}
+		db := mockDB(poolMock)
+
+		Convey("When GetGenericHierarchyAncestriesIDs is called", func() {
+			ids, err := db.GetGenericHierarchyAncestriesIDs(ctx, testAttempt, testCodeListID, testCodes)
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Then the expected list of unique IDs is returned and teh expected is executed, in any order of IDs", func() {
+				So(len(ids), ShouldEqual, 3)
+				So(ids, ShouldContain, "cpih1dim1aggid--cpih1dim1G90400")
+				So(ids, ShouldContain, "cpih1dim1aggid--cpih1dim1T90000")
+				So(ids, ShouldContain, "cpih1dim1aggid--cpih1dim1A0")
+				expectedQueryOp1 := `g.V().hasLabel('_generic_hierarchy_node_cpih1dim1aggid').has('code',within(["cpih1dim1S90401","cpih1dim1S90402"])).repeat(out('hasParent')).emit().id()`
+				expectedQueryOp2 := `g.V().hasLabel('_generic_hierarchy_node_cpih1dim1aggid').has('code',within(["cpih1dim1S90402","cpih1dim1S90401"])).repeat(out('hasParent')).emit().id()`
+				So(len(poolMock.GetStringListCalls()), ShouldEqual, 1)
+				So(poolMock.GetStringListCalls()[0].Query, ShouldBeIn, []string{expectedQueryOp1, expectedQueryOp2})
+			})
+		})
+	})
+}
+
+func TestNeptuneDB_CloneNodes(t *testing.T) {
+
+	Convey("Given a mocked neptune DB", t, func() {
+		poolMock := &internal.NeptunePoolMock{
+			ExecuteFunc: func(query string, bindings map[string]string, rebindings map[string]string) (responses []gremgo.Response, err error) {
+				return []gremgo.Response{}, nil
+			},
+		}
+		db := mockDB(poolMock)
+
+		Convey("When CloneNodes is called", func() {
+			err := db.CloneNodesFromIDs(ctx, testAttempt, testInstanceID, testCodeListID, testDimensionName, testIds, true)
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Then the expected query is sent to  Neptune to clone the nodes with the provided ids", func() {
+				expectedQueryFmt := `g.V('%s','%s').as('old')` +
+					`.addV('_hierarchy_node_f0a2f3f2-cc86-4bbb-a549-ffc99c89292c_aggregate')` +
+					`.property(single,'code',select('old').values('code'))` +
+					`.property(single,'label',select('old').values('label'))` +
+					`.property(single,'hasData', true)` +
+					`.property('code_list','cpih1dim1aggid').as('new')` +
+					`.addE('clone_of').to('old')`
+				expectedQueryOp1 := fmt.Sprintf(expectedQueryFmt, "cpih1dim1aggid--cpih1dim1S90401", "cpih1dim1aggid--cpih1dim1S90402")
+				expectedQueryOp2 := fmt.Sprintf(expectedQueryFmt, "cpih1dim1aggid--cpih1dim1S90402", "cpih1dim1aggid--cpih1dim1S90401")
+				So(len(poolMock.ExecuteCalls()), ShouldEqual, 1)
+				So(poolMock.ExecuteCalls()[0].Query, ShouldBeIn, []string{expectedQueryOp1, expectedQueryOp2})
+			})
+		})
+	})
+}
+
+func TestNeptuneDB_CountNodes(t *testing.T) {
+
+	Convey("Given a mocked neptune DB", t, func() {
+		var expectedCount int64 = 123
+		poolMock := &internal.NeptunePoolMock{
+			GetCountFunc: func(q string, bindings map[string]string, rebindings map[string]string) (int64, error) {
+				return expectedCount, nil
+			},
+		}
+		db := mockDB(poolMock)
+
+		Convey("When CountNodes is called", func() {
+			count, err := db.CountNodes(ctx, testInstanceID, testDimensionName)
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Then the expected query is sent to Neptune and the expected count is returned", func() {
+				So(count, ShouldEqual, expectedCount)
+				expectedQuery := `g.V().hasLabel('_hierarchy_node_f0a2f3f2-cc86-4bbb-a549-ffc99c89292c_aggregate').count()`
+				So(len(poolMock.GetCountCalls()), ShouldEqual, 1)
+				So(poolMock.GetCountCalls()[0].Q, ShouldEqual, expectedQuery)
+			})
+		})
+	})
+}
+
+func TestNeptuneDB_CloneRelationshipsFromIDs(t *testing.T) {
+
+	Convey("Given a mocked neptune DB", t, func() {
+		poolMock := &internal.NeptunePoolMock{
+			GetEFunc: func(q string, bindings, rebindings map[string]string) (resp interface{}, err error) {
+				return []graphson.Edge{}, nil
+			},
+		}
+		db := mockDB(poolMock)
+
+		Convey("When CloneRelationShips is called with duplicated IDs", func() {
+			err := db.CloneRelationshipsFromIDs(ctx, testAttempt, testInstanceID, testDimensionName, testAllIds)
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Then the expected query is sent to Neptune to clone the nodes with the unique provided IDs in any order", func() {
+				expectedQPrefix := `g.V('`
+				expectedQSuffix := `').as('oc')` +
+					`.out('hasParent')` +
+					`.in('clone_of').hasLabel('_hierarchy_node_f0a2f3f2-cc86-4bbb-a549-ffc99c89292c_aggregate').as('p')` +
+					`.select('oc').in('clone_of').hasLabel('_hierarchy_node_f0a2f3f2-cc86-4bbb-a549-ffc99c89292c_aggregate')` +
+					`.addE('hasParent').to('p')`
+				So(len(poolMock.GetECalls()), ShouldEqual, 1)
+				So(strings.HasPrefix(poolMock.GetECalls()[0].Q, expectedQPrefix), ShouldBeTrue)
+				So(strings.Count(poolMock.GetECalls()[0].Q, "'cpih1dim1aggid--cpih1dim1S90401'"), ShouldEqual, 1)
+				So(strings.Count(poolMock.GetECalls()[0].Q, "'cpih1dim1aggid--cpih1dim1S90402'"), ShouldEqual, 1)
+				So(strings.Count(poolMock.GetECalls()[0].Q, "'cpih1dim1aggid--cpih1dim1G90400'"), ShouldEqual, 1)
+				So(strings.Count(poolMock.GetECalls()[0].Q, "'cpih1dim1aggid--cpih1dim1T90000'"), ShouldEqual, 1)
+				So(strings.Count(poolMock.GetECalls()[0].Q, "'cpih1dim1aggid--cpih1dim1A0'"), ShouldEqual, 1)
+				So(strings.HasSuffix(poolMock.GetECalls()[0].Q, expectedQSuffix), ShouldBeTrue)
+			})
+		})
+	})
+}
+
+func TestNeptuneDB_RemoveCloneEdges(t *testing.T) {
+
+	Convey("Given a mocked neptune DB", t, func() {
+		poolMock := &internal.NeptunePoolMock{
+			ExecuteFunc: func(query string, bindings map[string]string, rebindings map[string]string) (responses []gremgo.Response, err error) {
+				return []gremgo.Response{}, nil
+			},
+		}
+		db := mockDB(poolMock)
+
+		Convey("When RemoveCloneEdges is called", func() {
+			err := db.RemoveCloneEdges(ctx, testAttempt, testInstanceID, testDimensionName)
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Then the clone relationships are removed", func() {
+				expectedQuery := `g.V().hasLabel('_hierarchy_node_f0a2f3f2-cc86-4bbb-a549-ffc99c89292c_aggregate').outE('clone_of').drop()`
+				So(len(poolMock.ExecuteCalls()), ShouldEqual, 1)
+				So(poolMock.ExecuteCalls()[0].Query, ShouldEqual, expectedQuery)
+			})
+		})
+	})
+}
+
+func TestNeptuneDB_SetNumberOfChildren(t *testing.T) {
+
+	Convey("Given a mocked neptune DB", t, func() {
+		poolMock := &internal.NeptunePoolMock{
+			ExecuteFunc: func(query string, bindings map[string]string, rebindings map[string]string) (responses []gremgo.Response, err error) {
+				return []gremgo.Response{}, nil
+			},
+		}
+		db := mockDB(poolMock)
+
+		Convey("When SetNumberOfChildren is called", func() {
+			err := db.SetNumberOfChildren(ctx, testAttempt, testInstanceID, testDimensionName)
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Then the expected query is sent to Neptune to clone the nodes with the unique provided IDs in any order", func() {
+				expectedQuery := `g.V().hasLabel('_hierarchy_node_f0a2f3f2-cc86-4bbb-a549-ffc99c89292c_aggregate').property(single,'numberOfChildren',__.in('hasParent').count())`
+				So(len(poolMock.ExecuteCalls()), ShouldEqual, 1)
+				So(poolMock.ExecuteCalls()[0].Query, ShouldResemble, expectedQuery)
+			})
+		})
+	})
+}
 
 func TestNeptuneDB_SetHasData(t *testing.T) {
 
@@ -34,7 +287,7 @@ func TestNeptuneDB_SetHasData(t *testing.T) {
 			})
 
 			Convey("Then the expected query is sent to Neptune to set the hasData property", func() {
-				expectedQuery := `g.V().hasLabel('_hierarchy_node_instanceID_dimensionName').as('v').has('code',within(["123","456","789"])).property(single,'hasData',true)`
+				expectedQuery := `g.V().hasLabel('_hierarchy_node_instanceID_dimensionName').as('v').has('code',within(["cpih1dim1S90401","cpih1dim1S90402"])).property(single,'hasData',true)`
 				So(poolMock.ExecuteCalls()[0].Query, ShouldEqual, expectedQuery)
 			})
 		})

--- a/neptune/hierarchy_test.go
+++ b/neptune/hierarchy_test.go
@@ -80,8 +80,8 @@ func TestNeptuneDB_GetGenericHierarchyNodeIDs(t *testing.T) {
 				So(len(ids), ShouldEqual, 2)
 				So(ids, ShouldContain, "cpih1dim1aggid--cpih1dim1S90401")
 				So(ids, ShouldContain, "cpih1dim1aggid--cpih1dim1S90402")
-				expectedQueryOp1 := `g.V().hasLabel('_generic_hierarchy_node_cpih1dim1aggid').has('code',within(["cpih1dim1S90401","cpih1dim1S90402"])).id()`
-				expectedQueryOp2 := `g.V().hasLabel('_generic_hierarchy_node_cpih1dim1aggid').has('code',within(["cpih1dim1S90402","cpih1dim1S90401"])).id()`
+				expectedQueryOp1 := `g.V().hasLabel('_generic_hierarchy_node_cpih1dim1aggid').has('code',within(['cpih1dim1S90401','cpih1dim1S90402'])).id()`
+				expectedQueryOp2 := `g.V().hasLabel('_generic_hierarchy_node_cpih1dim1aggid').has('code',within(['cpih1dim1S90402','cpih1dim1S90401'])).id()`
 				So(len(poolMock.GetStringListCalls()), ShouldEqual, 1)
 				So(poolMock.GetStringListCalls()[0].Query, ShouldBeIn, []string{expectedQueryOp1, expectedQueryOp2})
 			})
@@ -109,8 +109,8 @@ func TestNeptuneDB_GetGenericHierarchyAncestriesIDs(t *testing.T) {
 				So(ids, ShouldContain, "cpih1dim1aggid--cpih1dim1G90400")
 				So(ids, ShouldContain, "cpih1dim1aggid--cpih1dim1T90000")
 				So(ids, ShouldContain, "cpih1dim1aggid--cpih1dim1A0")
-				expectedQueryOp1 := `g.V().hasLabel('_generic_hierarchy_node_cpih1dim1aggid').has('code',within(["cpih1dim1S90401","cpih1dim1S90402"])).repeat(out('hasParent')).emit().id()`
-				expectedQueryOp2 := `g.V().hasLabel('_generic_hierarchy_node_cpih1dim1aggid').has('code',within(["cpih1dim1S90402","cpih1dim1S90401"])).repeat(out('hasParent')).emit().id()`
+				expectedQueryOp1 := `g.V().hasLabel('_generic_hierarchy_node_cpih1dim1aggid').has('code',within(['cpih1dim1S90401','cpih1dim1S90402'])).repeat(out('hasParent')).emit().id()`
+				expectedQueryOp2 := `g.V().hasLabel('_generic_hierarchy_node_cpih1dim1aggid').has('code',within(['cpih1dim1S90402','cpih1dim1S90401'])).repeat(out('hasParent')).emit().id()`
 				So(len(poolMock.GetStringListCalls()), ShouldEqual, 1)
 				So(poolMock.GetStringListCalls()[0].Query, ShouldBeIn, []string{expectedQueryOp1, expectedQueryOp2})
 			})
@@ -384,7 +384,7 @@ func TestNeptuneDB_SetHasData(t *testing.T) {
 			})
 
 			Convey("Then the expected query is sent to Neptune to set the hasData property", func() {
-				expectedQuery := `g.V().hasLabel('_hierarchy_node_instanceID_dimensionName').as('v').has('code',within(["cpih1dim1S90401","cpih1dim1S90402"])).property(single,'hasData',true)`
+				expectedQuery := `g.V().hasLabel('_hierarchy_node_instanceID_dimensionName').as('v').has('code',within(['cpih1dim1S90401','cpih1dim1S90402'])).property(single,'hasData',true)`
 				So(poolMock.ExecuteCalls()[0].Query, ShouldEqual, expectedQuery)
 			})
 		})

--- a/neptune/internal/mockpoolutils.go
+++ b/neptune/internal/mockpoolutils.go
@@ -140,6 +140,16 @@ var ReturnGenericHierarchyAncestryIDs = func(query string, bindings map[string]s
 	return ids, nil
 }
 
+var ReturnHierarchyNodeIDs = func(query string, bindings map[string]string, rebindings map[string]string) ([]string, error) {
+	var ids []string
+	ids = append(ids, "62bab579-e923-7cb2-3be0-34d09dc0567b")
+	ids = append(ids, "acbab579-e923-87df-e59a-9daf2ffed388")
+	ids = append(ids, "b6bab57a-604d-8a7f-59f5-1d496c9b3ca5")
+	ids = append(ids, "08bab57a-604d-9cd9-492f-e879cee05502")
+	ids = append(ids, "6cbab57a-604d-f176-9370-c60c19369801")
+	return ids, nil
+}
+
 var ReturnInvalidCodeData = func(query string, bindings map[string]string, rebindings map[string]string) ([]string, error) {
 	var codes []string
 	codes = append(codes, "Not")

--- a/neptune/internal/mockpoolutils.go
+++ b/neptune/internal/mockpoolutils.go
@@ -3,6 +3,8 @@ package internal
 import (
 	"fmt"
 
+	"errors"
+
 	"github.com/ONSdigital/graphson"
 )
 
@@ -10,10 +12,6 @@ import (
 This module provides a handful of mock convenience functions that can be
 used to inject behaviour into NeptunePoolMock.
 */
-
-import (
-	"errors"
-)
 
 // ReturnOne is a mock implementation for NeptunePool.GetCount()
 // that always returns a count of 1.
@@ -119,10 +117,27 @@ var ReturnEmptyCodesList = func(query string, bindings map[string]string, rebind
 
 var ReturnCodesList = func(query string, bindings map[string]string, rebindings map[string]string) ([]string, error) {
 	var codes []string
-	codes = append(codes, "123")
-	codes = append(codes, "456")
-	codes = append(codes, "789")
+	codes = append(codes, "cpih1dim1S90401")
+	codes = append(codes, "cpih1dim1S90402")
 	return codes, nil
+}
+
+var ReturnGenericHierarchyLeavesIDs = func(query string, bindings map[string]string, rebindings map[string]string) ([]string, error) {
+	var ids []string
+	ids = append(ids, "cpih1dim1aggid--cpih1dim1S90401")
+	ids = append(ids, "cpih1dim1aggid--cpih1dim1S90402")
+	return ids, nil
+}
+
+var ReturnGenericHierarchyAncestryIDs = func(query string, bindings map[string]string, rebindings map[string]string) ([]string, error) {
+	var ids []string
+	ids = append(ids, "cpih1dim1aggid--cpih1dim1G90400")
+	ids = append(ids, "cpih1dim1aggid--cpih1dim1G90400")
+	ids = append(ids, "cpih1dim1aggid--cpih1dim1T90000")
+	ids = append(ids, "cpih1dim1aggid--cpih1dim1T90000")
+	ids = append(ids, "cpih1dim1aggid--cpih1dim1A0")
+	ids = append(ids, "cpih1dim1aggid--cpih1dim1A0")
+	return ids, nil
 }
 
 var ReturnInvalidCodeData = func(query string, bindings map[string]string, rebindings map[string]string) ([]string, error) {
@@ -140,6 +155,24 @@ var ReturnThreeCodes = func(query string, bindings map[string]string, rebindings
 		codes = append(codes, fmt.Sprintf("code_%d", i))
 	}
 	return codes, nil
+}
+
+var ReturnNodeLeavesIDs = func(query string, bindings map[string]string, rebindings map[string]string) ([]string, error) {
+	var ids []string
+	ids = append(ids, "cpih1dim1S90401")
+	ids = append(ids, "cpih1dim1S90402")
+	return ids, nil
+}
+
+var ReturnNodeAncestryIDs = func(query string, bindings map[string]string, rebindings map[string]string) ([]string, error) {
+	var ids []string
+	ids = append(ids, "cpih1dim1A0")
+	ids = append(ids, "cpih1dim1T90000")
+	ids = append(ids, "cpih1dim1G90400")
+	ids = append(ids, "cpih1dim1A0")
+	ids = append(ids, "cpih1dim1T90000")
+	ids = append(ids, "cpih1dim1G90400")
+	return ids, nil
 }
 
 func MakeHierarchyVertex(vertexLabel, code, codeLabel string, numberOfChildren int, hasData bool) graphson.Vertex {

--- a/neptune/mockedneptune.go
+++ b/neptune/mockedneptune.go
@@ -10,6 +10,6 @@ import (
 // database communication.
 func mockDB(poolMock *internal.NeptunePoolMock) *NeptuneDB {
 	driver := driver.NeptuneDriver{Pool: poolMock}
-	db := &NeptuneDB{driver, 5, 30}
+	db := &NeptuneDB{driver, 5, 30, 25000, 150, 150}
 	return db
 }

--- a/neptune/neptune.go
+++ b/neptune/neptune.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ONSdigital/dp-graph/v2/graph/driver"
 	"math"
 	"math/rand"
 	"strings"
 	"time"
+
+	"github.com/ONSdigital/dp-graph/v2/graph/driver"
 
 	neptune "github.com/ONSdigital/dp-graph/v2/neptune/driver"
 	"github.com/ONSdigital/graphson"
@@ -53,7 +54,7 @@ func New(dbAddr string, size, timeout, retries int, errs chan error) (n *Neptune
 
 func (n *NeptuneDB) getVertices(gremStmt string) (vertices []graphson.Vertex, err error) {
 	ctx := context.Background()
-	logData := log.Data{"fn": "getVertices", "statement": gremStmt, "attempt": 1}
+	logData := log.Data{"fn": "getVertices", "statement": statementSummary(gremStmt), "attempt": 1}
 
 	var res interface{}
 	for attempt := 1; attempt < n.maxAttempts; attempt++ {
@@ -86,7 +87,7 @@ func (n *NeptuneDB) getVertices(gremStmt string) (vertices []graphson.Vertex, er
 
 func (n *NeptuneDB) getStringList(gremStmt string) (strings []string, err error) {
 	ctx := context.Background()
-	logData := log.Data{"fn": "getStringList", "statement": gremStmt, "attempt": 1}
+	logData := log.Data{"fn": "getStringList", "statement": statementSummary(gremStmt), "attempt": 1}
 
 	for attempt := 1; attempt < n.maxAttempts; attempt++ {
 		if attempt > 1 {
@@ -104,6 +105,7 @@ func (n *NeptuneDB) getStringList(gremStmt string) (strings []string, err error)
 		}
 	}
 	// ASSERT: failed all attempts
+	logData["statement"] = gremStmt
 	log.Event(ctx, "maxAttempts reached", log.ERROR, logData, log.Error(err))
 	err = ErrAttemptsExceededLimit{err}
 	return
@@ -133,7 +135,7 @@ func (n *NeptuneDB) getVertex(gremStmt string) (vertex graphson.Vertex, err erro
 
 func (n *NeptuneDB) getEdges(gremStmt string) (edges []graphson.Edge, err error) {
 	ctx := context.Background()
-	logData := log.Data{"fn": "getEdges", "statement": gremStmt, "attempt": 1}
+	logData := log.Data{"fn": "getEdges", "statement": statementSummary(gremStmt), "attempt": 1}
 
 	var res interface{}
 	for attempt := 1; attempt < n.maxAttempts; attempt++ {
@@ -160,6 +162,7 @@ func (n *NeptuneDB) getEdges(gremStmt string) (edges []graphson.Edge, err error)
 		}
 	}
 	// ASSERT: failed all attempts
+	logData["statement"] = gremStmt
 	log.Event(ctx, "maxAttempts reached", log.ERROR, logData, log.Error(err))
 	err = ErrAttemptsExceededLimit{err}
 	return
@@ -167,7 +170,7 @@ func (n *NeptuneDB) getEdges(gremStmt string) (edges []graphson.Edge, err error)
 
 func (n *NeptuneDB) exec(gremStmt string) (res []gremgo.Response, err error) {
 	ctx := context.Background()
-	logData := log.Data{"fn": "n.exec", "statement": gremStmt, "attempt": 1}
+	logData := log.Data{"fn": "n.exec", "statement": statementSummary(gremStmt), "attempt": 1}
 
 	for attempt := 1; attempt < n.maxAttempts; attempt++ {
 		if attempt > 1 {
@@ -191,6 +194,7 @@ func (n *NeptuneDB) exec(gremStmt string) (res []gremgo.Response, err error) {
 		}
 	}
 	// ASSERT: failed all attempts
+	logData["statement"] = gremStmt
 	log.Event(ctx, "maxAttempts reached", log.ERROR, logData, log.Error(err))
 	err = ErrAttemptsExceededLimit{err}
 	return
@@ -198,7 +202,7 @@ func (n *NeptuneDB) exec(gremStmt string) (res []gremgo.Response, err error) {
 
 func (n *NeptuneDB) getNumber(gremStmt string) (count int64, err error) {
 	ctx := context.Background()
-	logData := log.Data{"fn": "n.getNumber", "statement": gremStmt, "attempt": 1}
+	logData := log.Data{"fn": "n.getNumber", "statement": statementSummary(gremStmt), "attempt": 1}
 
 	for attempt := 1; attempt < n.maxAttempts; attempt++ {
 		if attempt > 1 {
@@ -216,6 +220,7 @@ func (n *NeptuneDB) getNumber(gremStmt string) (count int64, err error) {
 		}
 	}
 	// ASSERT: failed all attempts
+	logData["statement"] = gremStmt
 	log.Event(ctx, "maxAttempts reached", log.ERROR, logData, log.Error(err))
 	err = ErrAttemptsExceededLimit{err}
 	return

--- a/neptune/neptune.go
+++ b/neptune/neptune.go
@@ -20,11 +20,14 @@ import (
 type NeptuneDB struct {
 	neptune.NeptuneDriver
 
-	maxAttempts int
-	timeout     int
+	maxAttempts     int
+	timeout         int
+	batchSizeReader int
+	batchSizeWriter int
+	maxWorkers      int
 }
 
-func New(dbAddr string, size, timeout, retries int, errs chan error) (n *NeptuneDB, err error) {
+func New(dbAddr string, size, timeout, retries, batchSizeReader, batchSizeWriter, maxWorkers int, errs chan error) (n *NeptuneDB, err error) {
 	// set defaults if not provided
 	if size == 0 {
 		size = 30
@@ -34,6 +37,15 @@ func New(dbAddr string, size, timeout, retries int, errs chan error) (n *Neptune
 	}
 	if retries == 0 {
 		retries = 5
+	}
+	if batchSizeReader == 0 {
+		batchSizeReader = 25000
+	}
+	if batchSizeWriter == 0 {
+		batchSizeWriter = 150
+	}
+	if maxWorkers == 0 {
+		maxWorkers = 150
 	}
 
 	var d *neptune.NeptuneDriver
@@ -48,6 +60,9 @@ func New(dbAddr string, size, timeout, retries int, errs chan error) (n *Neptune
 		*d,
 		1 + retries,
 		timeout,
+		batchSizeReader,
+		batchSizeWriter,
+		maxWorkers,
 	}
 	return
 }

--- a/neptune/neptune.go
+++ b/neptune/neptune.go
@@ -185,7 +185,6 @@ func (n *NeptuneDB) exec(gremStmt string) (res []gremgo.Response, err error) {
 				log.Event(ctx, "bad res", log.ERROR, logData, log.Error(err))
 				return
 			}
-			log.Event(ctx, "exec ok", log.INFO, logData)
 			return
 		}
 		// XXX check err more thoroughly (isTransientError?) (non-err failures?)

--- a/neptune/query/query.go
+++ b/neptune/query/query.go
@@ -50,17 +50,21 @@ const (
 		union(select('rl', 'de', 'dv', 'did')).unfold().select(values)
 	`
 
+	// Get ids for generic hierarchy nodes with provided codes and its ancestries. Note: the returned array will have duplicated values (one for each time a subtree is traversed)
+	// GetHierarchyNodeIDs = `g.V().hasLabel('_generic_hierarchy_node_%s).has('code',within(%s)).repeat(out('hasParent')).emit().id()`
+	GetHierarchyNodeIDs     = `g.V().hasLabel('_generic_hierarchy_node_%s').has('code',within(%s)).id()`
+	GetHierarchyAncestryIDs = `g.V().hasLabel('_generic_hierarchy_node_%s').has('code',within(%s)).repeat(out('hasParent')).emit().id()`
+
 	// hierarchy write
-	CloneHierarchyNodes = `g.V().hasLabel('_generic_hierarchy_node_%s').as('old')` +
+	CloneHierarchyNodes = `g.V(%s).as('old')` +
 		`.addV('_hierarchy_node_%s_%s')` +
 		`.property(single,'code',select('old').values('code'))` +
 		`.property(single,'label',select('old').values('label'))` +
-		`.property(single,'hasData', false)` +
+		`.property(single,'hasData', %t)` +
 		`.property('code_list','%s').as('new')` +
-		`.addE('clone_of').to('old')` +
-		`.select('new')`
+		`.addE('clone_of').to('old')`
 	CountHierarchyNodes         = `g.V().hasLabel('_hierarchy_node_%s_%s').count()`
-	CloneHierarchyRelationships = `g.V().hasLabel('_generic_hierarchy_node_%s').as('oc')` +
+	CloneHierarchyRelationships = `g.V(%s).as('oc')` +
 		`.out('hasParent')` +
 		`.in('clone_of').hasLabel('_hierarchy_node_%s_%s').as('p')` +
 		`.select('oc').in('clone_of').hasLabel('_hierarchy_node_%s_%s')` +

--- a/neptune/utils.go
+++ b/neptune/utils.go
@@ -1,6 +1,7 @@
 package neptune
 
 import (
+	"strings"
 	"sync"
 )
 
@@ -103,4 +104,17 @@ func createMap(a ...[]string) (m map[string]struct{}) {
 		}
 	}
 	return m
+}
+
+// statementSummary returns a summarized statement for logging, removing long lists of IDs or codes
+func statementSummary(stmt string) string {
+	if strings.HasPrefix(stmt, "g.V('") {
+		i := strings.Index(stmt, "')")
+		return "g.V(...)" + stmt[i+2:]
+	}
+	if i := strings.Index(stmt, "within(["); i != -1 {
+		j := strings.Index(stmt[i:], "])")
+		return stmt[:i] + "within([...])" + stmt[i+j+2:]
+	}
+	return stmt
 }

--- a/neptune/utils.go
+++ b/neptune/utils.go
@@ -1,0 +1,106 @@
+package neptune
+
+import (
+	"sync"
+)
+
+// batchProcessor defines a generic function type to process a batch (array of strings) and may return a result (array of strings) and an error.
+type batchProcessor = func([]string) ([]string, error)
+
+// processInConcurrentBatches splits the provided items in batches and calls processBatch for each batch batch, concurrently.
+// The results of the batch Processor functions, if provided, are aggregated as unique items and returned.
+func processInConcurrentBatches(items []string, processBatch batchProcessor, batchSize int) (result map[string]struct{}, numChunks int, errs []error) {
+	wg := sync.WaitGroup{}
+	chWait := make(chan struct{})
+	chErr := make(chan error)
+
+	result = make(map[string]struct{})
+	lockResult := sync.Mutex{}
+
+	// func executed in each go-routine to process the batch, aggregate results, and send errors to the error channel
+	doProcessBatch := func(chunk []string) {
+		defer wg.Done()
+		res, err := processBatch(chunk)
+		if err != nil {
+			chErr <- err
+			return
+		}
+		lockResult.Lock()
+		for _, resItem := range res {
+			result[resItem] = struct{}{}
+		}
+		lockResult.Unlock()
+	}
+
+	// func that triggers the batch processing for a chunk, in a parallel go-routine
+	goProcessBatch := func(chunk []string) {
+		wg.Add(1)
+		go doProcessBatch(chunk)
+	}
+
+	// split in batches, and trigger a go-routine for each batch
+	numChunks = processInBatches(items, goProcessBatch, batchSize)
+
+	// func that will close wait channel when all go-routines complete their execution
+	go func() {
+		wg.Wait()
+		close(chWait)
+	}()
+
+	// Block until all workers finish their work, keeping track of errors
+	for {
+		select {
+		case err := <-chErr:
+			errs = append(errs, err)
+		case <-chWait:
+			return
+		}
+	}
+}
+
+// processInBatches is an aux function that splits the provided items in batches and calls processBatch for each batch
+func processInBatches(items []string, processBatch func([]string), batchSize int) (numChunks int) {
+	// Get bath splits for provided items
+	numFullChunks := len(items) / batchSize
+	remainingSize := len(items) % batchSize
+	numChunks = numFullChunks
+
+	// process full batches
+	for i := 0; i < numFullChunks; i++ {
+		chunk := items[i*batchSize : (i+1)*batchSize]
+		processBatch(chunk)
+	}
+
+	// process any remaining
+	if remainingSize > 0 {
+		numChunks = numFullChunks + 1
+		lastChunk := items[numFullChunks*batchSize : (numFullChunks*batchSize + remainingSize)]
+		processBatch(lastChunk)
+	}
+	return numChunks
+}
+
+// unique returns an array containing the unique elements of the provided array
+func unique(duplicated []string) (unique []string) {
+	return createArray(createMap(duplicated))
+}
+
+// createArray creates an array of keys from the provided map
+func createArray(m map[string]struct{}) (a []string) {
+	for k := range m {
+		a = append(a, k)
+	}
+	return a
+}
+
+// createMap creates a map whose keys are the unique values of the provided array(s).
+// values are empty structs for memory efficiency reasons (no storage used)
+func createMap(a ...[]string) (m map[string]struct{}) {
+	m = make(map[string]struct{})
+	for _, aa := range a {
+		for _, val := range aa {
+			m[val] = struct{}{}
+		}
+	}
+	return m
+}

--- a/neptune/utils.go
+++ b/neptune/utils.go
@@ -5,21 +5,12 @@ import (
 	"sync"
 )
 
-// batchSize is the size of each batch for queries that are run concurrently in batches
-const (
-	batchSizeReader = 25000
-	batchSizeWriter = 150
-)
-
-// maxWorkers is the maximum number of parallel go-routines that will trigger gremlin queries for a particular task
-const maxWorkers = 150
-
 // batchProcessor defines a generic function type to process a batch (array of strings) and may return a result (array of strings) and an error.
 type batchProcessor = func([]string) ([]string, error)
 
 // processInConcurrentBatches splits the provided items in batches and calls processBatch for each batch batch, concurrently.
 // The results of the batch Processor functions, if provided, are aggregated as unique items and returned.
-func processInConcurrentBatches(items []string, processBatch batchProcessor, batchSize int) (result map[string]struct{}, numChunks int, errs []error) {
+func processInConcurrentBatches(items []string, processBatch batchProcessor, batchSize, maxWorkers int) (result map[string]struct{}, numChunks int, errs []error) {
 	wg := sync.WaitGroup{}
 	chWait := make(chan struct{})
 	chErr := make(chan error)

--- a/neptune/utils_test.go
+++ b/neptune/utils_test.go
@@ -97,7 +97,7 @@ func TestInConcurrentBatches(t *testing.T) {
 
 			Convey("Then processing the chunks concurrently results in an aggregated empty array, "+
 				"the expected number of chunks and no error being returned", func() {
-				result, numChunks, errs := processInConcurrentBatches(items, processor, 5)
+				result, numChunks, errs := processInConcurrentBatches(items, processor, 5, 150)
 				So(result, ShouldResemble, make(map[string]struct{}))
 				So(numChunks, ShouldEqual, 2)
 				So(errs, ShouldBeNil)
@@ -121,7 +121,7 @@ func TestInConcurrentBatches(t *testing.T) {
 
 				Convey("Then processing the chunks concurrently results in an aggregated array of the union of returned items, "+
 					"the expected number of chunks and no error being returned", func() {
-					result, numChunks, errs := processInConcurrentBatches(items, processor, 5)
+					result, numChunks, errs := processInConcurrentBatches(items, processor, 5, 150)
 					So(result, ShouldResemble, map[string]struct{}{"a": {}, "b": {}, "c": {}, "d": {}})
 					So(numChunks, ShouldEqual, 2)
 					So(errs, ShouldBeNil)
@@ -141,7 +141,7 @@ func TestInConcurrentBatches(t *testing.T) {
 				}
 
 				Convey("Then processing the chunks concurrently results in all errors being returned", func() {
-					result, numChunks, errs := processInConcurrentBatches(items, processor, 5)
+					result, numChunks, errs := processInConcurrentBatches(items, processor, 5, 150)
 					So(result, ShouldResemble, make(map[string]struct{}))
 					So(numChunks, ShouldEqual, 2)
 					So(errs, ShouldResemble, []error{testErr, testErr})

--- a/neptune/utils_test.go
+++ b/neptune/utils_test.go
@@ -153,3 +153,23 @@ func TestInConcurrentBatches(t *testing.T) {
 		})
 	})
 }
+
+func TestStatementSummary(t *testing.T) {
+
+	Convey("A statement without any list of IDs or codes is summarized to itself", t, func() {
+		original := "g.V().hasLabel('_hierarchy_node_instance_dim').id()"
+		So(statementSummary(original), ShouldResemble, original)
+	})
+
+	Convey("A statement that starts querying a list of vertices by ID is summarized to the same without showing the IDs", t, func() {
+		original := "g.V('node1','node2','node3').outE('clone_of').drop()"
+		expected := "g.V(...).outE('clone_of').drop()"
+		So(statementSummary(original), ShouldResemble, expected)
+	})
+
+	Convey("A statement that requests an element 'within' a list is summarized to the same without showing the list of elements", t, func() {
+		original := "g.V().hasLabel('_generic_hierarchy_node_output-area-geography').has('code',within(['code1','code2','code3'])).id()"
+		expected := "g.V().hasLabel('_generic_hierarchy_node_output-area-geography').has('code',within([...])).id()"
+		So(statementSummary(original), ShouldResemble, expected)
+	})
+}

--- a/neptune/utils_test.go
+++ b/neptune/utils_test.go
@@ -1,0 +1,155 @@
+package neptune
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/pkg/errors"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestCreateMap(t *testing.T) {
+
+	Convey("Given two string array with duplicated values", t, func() {
+		a := []string{"0", "1", "2", "2"}
+		b := []string{"0", "3", "3"}
+
+		Convey("Then createMap returns a map of empty structs where the keys are the union of all array items", func() {
+			m := createMap(a, b)
+			So(m, ShouldResemble, map[string]struct{}{"0": {}, "1": {}, "2": {}, "3": {}})
+		})
+	})
+}
+
+func TestCreateArray(t *testing.T) {
+
+	Convey("Given an empty struct map", t, func() {
+		m := map[string]struct{}{"0": {}, "1": {}, "2": {}}
+
+		Convey("Then createArray returns an array of strings containing the keys, in any order", func() {
+			a := createArray(m)
+			So(len(a), ShouldEqual, 3)
+			So(a, ShouldContain, "0")
+			So(a, ShouldContain, "1")
+			So(a, ShouldContain, "2")
+		})
+	})
+}
+
+func TestUnique(t *testing.T) {
+
+	Convey("Given a string array with duplicated values", t, func() {
+		a := []string{"0", "1", "2", "0"}
+
+		Convey("Then unique returns an array of unique values from the original array", func() {
+			b := unique(a)
+			So(len(b), ShouldEqual, 3)
+			So(b, ShouldContain, "0")
+			So(b, ShouldContain, "1")
+			So(b, ShouldContain, "2")
+		})
+	})
+}
+
+func TestProcessInBatches(t *testing.T) {
+
+	Convey("Given an array of 10 items and a mock chunk processor function", t, func() {
+		items := []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"}
+		processedChunks := [][]string{}
+		processor := func(chunk []string) { processedChunks = append(processedChunks, chunk) }
+
+		Convey("Then processing in chunks of size 5 results in the function being called twice with the expected chunks", func() {
+			numChunks := processInBatches(items, processor, 5)
+			So(numChunks, ShouldEqual, 2)
+			So(processedChunks, ShouldResemble, [][]string{
+				{"0", "1", "2", "3", "4"},
+				{"5", "6", "7", "8", "9"}})
+		})
+
+		Convey("Then processing in chunks of size 3 results in the function being called four times with the expected chunks, the last one being containing the remaining items", func() {
+			numChunks := processInBatches(items, processor, 3)
+			So(numChunks, ShouldEqual, 4)
+			So(processedChunks, ShouldResemble, [][]string{
+				{"0", "1", "2"},
+				{"3", "4", "5"},
+				{"6", "7", "8"},
+				{"9"}})
+		})
+	})
+}
+
+func TestInConcurrentBatches(t *testing.T) {
+
+	Convey("Given an array of 10 items", t, func() {
+		items := []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"}
+		processedChunks := [][]string{}
+		lock := sync.Mutex{}
+		chunk1 := []string{"0", "1", "2", "3", "4"}
+		chunk2 := []string{"5", "6", "7", "8", "9"}
+
+		Convey("And a successful mock chunk processor function that returns an empty array", func() {
+			processor := func(chunk []string) ([]string, error) {
+				defer lock.Unlock()
+				lock.Lock()
+				processedChunks = append(processedChunks, chunk)
+				return []string{}, nil
+			}
+
+			Convey("Then processing the chunks concurrently results in an aggregated empty array, "+
+				"the expected number of chunks and no error being returned", func() {
+				result, numChunks, errs := processInConcurrentBatches(items, processor, 5)
+				So(result, ShouldResemble, make(map[string]struct{}))
+				So(numChunks, ShouldEqual, 2)
+				So(errs, ShouldBeNil)
+				So(len(processedChunks), ShouldEqual, 2)
+				So(processedChunks, ShouldContain, chunk1)
+				So(processedChunks, ShouldContain, chunk2)
+			})
+
+			Convey("And a successful mock chunk processor function that returns duplicated values", func() {
+				numCall := 0
+				processor := func(chunk []string) ([]string, error) {
+					defer lock.Unlock()
+					lock.Lock()
+					processedChunks = append(processedChunks, chunk)
+					numCall++
+					if numCall == 1 {
+						return []string{"a", "b", "b", "a"}, nil
+					}
+					return []string{"a", "c", "d", "c"}, nil
+				}
+
+				Convey("Then processing the chunks concurrently results in an aggregated array of the union of returned items, "+
+					"the expected number of chunks and no error being returned", func() {
+					result, numChunks, errs := processInConcurrentBatches(items, processor, 5)
+					So(result, ShouldResemble, map[string]struct{}{"a": {}, "b": {}, "c": {}, "d": {}})
+					So(numChunks, ShouldEqual, 2)
+					So(errs, ShouldBeNil)
+					So(len(processedChunks), ShouldEqual, 2)
+					So(processedChunks, ShouldContain, chunk1)
+					So(processedChunks, ShouldContain, chunk2)
+				})
+			})
+
+			Convey("And an erroring mock chunk processor function", func() {
+				testErr := errors.New("testErr")
+				processor := func(chunk []string) ([]string, error) {
+					defer lock.Unlock()
+					lock.Lock()
+					processedChunks = append(processedChunks, chunk)
+					return []string{"shouldBeIgnored"}, testErr
+				}
+
+				Convey("Then processing the chunks concurrently results in all errors being returned", func() {
+					result, numChunks, errs := processInConcurrentBatches(items, processor, 5)
+					So(result, ShouldResemble, make(map[string]struct{}))
+					So(numChunks, ShouldEqual, 2)
+					So(errs, ShouldResemble, []error{testErr, testErr})
+					So(len(processedChunks), ShouldEqual, 2)
+					So(processedChunks, ShouldContain, chunk1)
+					So(processedChunks, ShouldContain, chunk2)
+				})
+			})
+		})
+	})
+}


### PR DESCRIPTION
### What

- New hierarchy build algorithm:
Instead of cloning all generic hierarchy nodes, and then removing the nodes that we don't need, now we check what node IDs we need to clone and clone them.
  - Created new queries in Neptune to implement the new hierarchy build algorithm.
  - Modified the driver hierarchy interface accordingly
  - Kept old methods, as Neo4j doesn't implement the new ones.
  - return ErrNotImplemented in Neo4j for the new methods.

- Batch processing:
Starting queries by selecting nodes by ID allows us to spit the queries in batches. Implemented the following batch strategy for Neptune:
  - Different batch sizes for write and read operations (reads queries can handle much larger batch sizes)
  - Batch queries are executed in parallel, by concurrent worker go-routines. We limit the number of concurrent workers to prevent doing a DOS attack to Neptune for large queries.
  - The new batch processing was abstracted, implemented in utils.go, so that it can be reused by other functions in the future.

- More info in [spike document](https://docs.google.com/document/d/1AiEf4-b-D1goQaW0MWD5J-QSV3PWFF3j5zrKAc7lAp4/edit)

### How to review

- Make sure unit tests pass
- Make sure code changes make sense

### Who can review

Anyone with Gremlin experience