### PR TITLE
Rework Neptune observation import to allow concurrent processes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/golang-neo4j-bolt-driver v0.0.0-20190228153339-da534111531d
-	github.com/ONSdigital/graphson v0.0.0-20190718134034-c13ceacd109d
+	github.com/ONSdigital/graphson v0.1.0
 	github.com/ONSdigital/gremgo-neptune v1.0.0
 	github.com/ONSdigital/log.go v1.0.1
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/ONSdigital/golang-neo4j-bolt-driver v0.0.0-20190228153339-da534111531
 github.com/ONSdigital/golang-neo4j-bolt-driver v0.0.0-20190228153339-da534111531d/go.mod h1:75Sxr59AMz2RiPskqSymLFxdeaIEhnkNaJE5lonMS3M=
 github.com/ONSdigital/graphson v0.0.0-20190718134034-c13ceacd109d h1:yrCtEGlohmA3OnXtke0nOOp/m9O83orpSnTGOfYOw1Q=
 github.com/ONSdigital/graphson v0.0.0-20190718134034-c13ceacd109d/go.mod h1:zQ+8pTnCLGuy4eUek81pWUxZo4/f71ri3VYz97Wby+4=
+github.com/ONSdigital/graphson v0.1.0 h1:Z+9l9RGnSG5OU5sx/QanLEfhrHGqY+hni+7NJ2TLFAY=
+github.com/ONSdigital/graphson v0.1.0/go.mod h1:IRS8d1ydh1oczDKbLhTcqc/BNfgZyzhrrjr21SQOkjA=
 github.com/ONSdigital/gremgo-neptune v1.0.0 h1:l0Pizt2goXK5oCFeqs2sOkosZbF4sva0RpcR150VvNE=
 github.com/ONSdigital/gremgo-neptune v1.0.0/go.mod h1:GZz/N6xjNY+EN0x4FmfBDrM73R+Pr3aI5iCwYbY1oYQ=
 github.com/ONSdigital/log.go v1.0.0 h1:hZQTuitFv4nSrpzMhpGvafUC5/8xMVnLI0CWe1rAJNc=

--- a/neptune/query/query.go
+++ b/neptune/query/query.go
@@ -107,10 +107,14 @@ const (
 		`.addE('HAS_DIMENSION').to('inst').select('d')`
 
 	// observation
-	DropObservationRelationships   = `g.V().hasLabel('_%s_observation').has('value', '%s').bothE().drop().iterate();`
-	DropObservation                = `g.V().hasLabel('_%s_observation').has('value', '%s').drop().iterate();`
-	CreateObservationPart          = `g.addV('_%s_observation').as('o').property(single, 'value', '%s').property(single, 'rowIndex', '%d')`
-	AddObservationRelationshipPart = `.V().hasId('%s').addE('isValueOf').from('o')`
+	GetObservations      = `g.V(%s).id()`
+	GetObservationsEdges = `g.V(%s).bothE().id()`
+	DropObservationEdges = `g.E(%s).drop().iterate();`
+	DropObservations     = `g.V(%s).drop()`
+
+	CreateObservationPart  = `.addV('_%s_observation').property(id, '%s').property(single, 'value', '%s')`
+	DimensionLookupPart    = `.V('%s').as('%s')`
+	AddObservationEdgePart = `.V('%s').addE('isValueOf').to('%s')`
 
 	GetInstanceHeaderPart       = `g.V().hasId('_%s_Instance').values('header')`
 	GetAllObservationsPart      = `g.V().hasLabel('_%s_observation')`


### PR DESCRIPTION
### What
https://trello.com/c/w5W7xaSw/4911-improve-reliability-of-observation-import-queries

- use new version of graphson, which does not error when an empty result set is returned - preventing retries for queries that should not be retried.
- Rework Neptune observation import to allow concurrent processes. 
Neptune has an aggressive locking strategy, which prevented the previous implementation from working concurrently. This change separates read and write parts of the query. It also minimises the overhead of the write queries to prevent lock contention when running multiple instances.

### How to review
Review code / tests

If you want to test - you would need to run multiple instances of the observation importer, ensuring that this branch of code is used. (either using replace in go.mod, or refer to commit `b096517db8d28020dce7eabef0fb6c070a65c6e2 ` )

### Who can review

