### PR TITLE
Feature/neptune dimension import perf

### DIFF
--- a/neptune/dimension_test.go
+++ b/neptune/dimension_test.go
@@ -2,15 +2,54 @@ package neptune
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"github.com/ONSdigital/dp-graph/v2/models"
 	"github.com/ONSdigital/dp-graph/v2/neptune/internal"
 	"github.com/ONSdigital/graphson"
+	"github.com/ONSdigital/gremgo-neptune"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestNeptuneDB_InsertDimension(t *testing.T) {
+
+	createPoolMock := func(expectedVertices []graphson.Vertex) *internal.NeptunePoolMock {
+		poolMock := &internal.NeptunePoolMock{
+			GetFunc: func(query string, bindings map[string]string, rebindings map[string]string) ([]graphson.Vertex, error) {
+				return expectedVertices, nil
+			},
+			GetStringListFunc: func(query string, bindings map[string]string, rebindings map[string]string) ([]string, error) {
+				return []string{}, nil
+			},
+			ExecuteFunc: func(query string, bindings map[string]string, rebindings map[string]string) ([]gremgo.Response, error) {
+				return []gremgo.Response{}, nil
+			},
+		}
+		return poolMock
+	}
+
+	createDimension := func() *models.Dimension {
+		return &models.Dimension{
+			DimensionID: "dimID",
+			Option:      "option",
+			NodeID:      "nodeID",
+		}
+	}
+
+	createVertices := func() []graphson.Vertex {
+		expectedVertex := graphson.Vertex{
+			Type: "",
+			Value: graphson.VertexValue{
+				ID:         "123",
+				Label:      "",
+				Properties: nil,
+			},
+		}
+		expectedVertices := []graphson.Vertex{expectedVertex}
+		return expectedVertices
+	}
 
 	ctx := context.Background()
 	instanceID := "instanceID"
@@ -19,7 +58,7 @@ func TestNeptuneDB_InsertDimension(t *testing.T) {
 
 		uniqueDimensions := map[string]string{}
 		dimension := createDimension()
-		db := createMockDB(createVertices())
+		db := mockDB(createPoolMock(createVertices()))
 		instanceID := ""
 
 		Convey("When InsertDimension is called", func() {
@@ -36,7 +75,7 @@ func TestNeptuneDB_InsertDimension(t *testing.T) {
 
 	Convey("Given a nil dimension value", t, func() {
 		uniqueDimensions := map[string]string{}
-		db := createMockDB(createVertices())
+		db := mockDB(createPoolMock(createVertices()))
 		var dimension *models.Dimension
 
 		Convey("When InsertDimension is called", func() {
@@ -54,7 +93,7 @@ func TestNeptuneDB_InsertDimension(t *testing.T) {
 	Convey("Given an empty dimension ID", t, func() {
 		uniqueDimensions := map[string]string{}
 		dimension := createDimension()
-		db := createMockDB(createVertices())
+		db := mockDB(createPoolMock(createVertices()))
 
 		dimension.DimensionID = ""
 
@@ -72,7 +111,7 @@ func TestNeptuneDB_InsertDimension(t *testing.T) {
 	Convey("Given an empty dimension option value", t, func() {
 		uniqueDimensions := map[string]string{}
 		dimension := createDimension()
-		db := createMockDB(createVertices())
+		db := mockDB(createPoolMock(createVertices()))
 
 		dimension.Option = ""
 
@@ -90,7 +129,7 @@ func TestNeptuneDB_InsertDimension(t *testing.T) {
 	Convey("Given an empty dimension ID and option value", t, func() {
 		uniqueDimensions := map[string]string{}
 		dimension := createDimension()
-		db := createMockDB(createVertices())
+		db := mockDB(createPoolMock(createVertices()))
 
 		dimension.DimensionID = ""
 		dimension.Option = ""
@@ -106,53 +145,90 @@ func TestNeptuneDB_InsertDimension(t *testing.T) {
 		})
 	})
 
-	Convey("Given a dimension to insert", t, func() {
+	Convey("Given a dimension already exists", t, func() {
 
 		uniqueDimensions := map[string]string{}
 		dimension := createDimension()
-		expectedVertices := createVertices()
-		db := createMockDB(expectedVertices)
+		expectedDimID := fmt.Sprintf("_%s_%s_%s", instanceID, dimension.DimensionID, dimension.Option)
+		poolMock := createPoolMock(createVertices())
+		poolMock.GetStringListFunc = func(query string, bindings map[string]string, rebindings map[string]string) ([]string, error) {
+			return []string{expectedDimID}, nil
+		}
+		db := mockDB(poolMock)
 
 		Convey("When InsertDimension is called", func() {
 
 			insertedDimension, err := db.InsertDimension(ctx, uniqueDimensions, instanceID, dimension)
 
-			Convey("Then the dimension ID is returned", func() {
+			Convey("Then the existing dimension is deleted from the graph DB", func() {
+				So(len(poolMock.ExecuteCalls()), ShouldBeGreaterThan, 0)
+				expectedDropDimStmt := "g.V('_instanceID_dimID_option').bothE().drop().iterate();g.V('_instanceID_dimID_option').drop()"
+				So(poolMock.ExecuteCalls()[0].Query, ShouldEqual, expectedDropDimStmt)
+			})
+
+			Convey("Then the new dimension ID is returned", func() {
 				So(err, ShouldBeNil)
 				So(insertedDimension, ShouldNotBeNil)
-				So(insertedDimension.NodeID, ShouldEqual, expectedVertices[0].GetID())
+				So(insertedDimension.NodeID, ShouldEqual, expectedDimID)
 			})
 		})
 	})
-}
 
-func createMockDB(expectedVertices []graphson.Vertex) *NeptuneDB {
-	poolMock := &internal.NeptunePoolMock{
-		GetFunc: func(query string, bindings map[string]string, rebindings map[string]string) ([]graphson.Vertex, error) {
-			return expectedVertices, nil
-		},
-	}
-	db := mockDB(poolMock)
-	return db
-}
+	Convey("Given an error on dimension lookup", t, func() {
 
-func createDimension() *models.Dimension {
-	return &models.Dimension{
-		DimensionID: "dimID",
-		Option:      "option",
-		NodeID:      "nodeID",
-	}
-}
+		expectedErr := errors.New(" INVALID REQUEST ARGUMENTS ")
 
-func createVertices() []graphson.Vertex {
-	expectedVertex := graphson.Vertex{
-		Type: "",
-		Value: graphson.VertexValue{
-			ID:         "123",
-			Label:      "",
-			Properties: nil,
-		},
-	}
-	expectedVertices := []graphson.Vertex{expectedVertex}
-	return expectedVertices
+		uniqueDimensions := map[string]string{}
+		dimension := createDimension()
+		poolMock := createPoolMock(createVertices())
+		poolMock.GetStringListFunc = func(query string, bindings map[string]string, rebindings map[string]string) ([]string, error) {
+			return nil, expectedErr
+		}
+		db := mockDB(poolMock)
+
+		Convey("When InsertDimension is called", func() {
+
+			insertedDimension, err := db.InsertDimension(ctx, uniqueDimensions, instanceID, dimension)
+
+			Convey("Then the expected error is returned", func() {
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, expectedErr)
+				So(insertedDimension, ShouldBeNil)
+			})
+		})
+	})
+
+	Convey("Given a dimension to insert", t, func() {
+
+		uniqueDimensions := map[string]string{}
+		dimension := createDimension()
+		poolMock := createPoolMock(createVertices())
+		db := mockDB(poolMock)
+
+		Convey("When InsertDimension is called", func() {
+
+			insertedDimension, err := db.InsertDimension(ctx, uniqueDimensions, instanceID, dimension)
+
+			Convey("Then the graph DB is queried to see if the dimension exists", func() {
+				So(len(poolMock.GetStringListCalls()), ShouldEqual, 1)
+				expectedGetDimStmt := "g.V('_instanceID_dimID_option').id()"
+				So(poolMock.GetStringListCalls()[0].Query, ShouldEqual, expectedGetDimStmt)
+			})
+
+			Convey("Then the graph DB is called to insert the dimension", func() {
+				So(len(poolMock.ExecuteCalls()), ShouldEqual, 2)
+				expectedCreateDimStmt := "g.addV('_instanceID_dimID').property(id, '_instanceID_dimID_option').property('value',\"option\")"
+				So(poolMock.ExecuteCalls()[0].Query, ShouldEqual, expectedCreateDimStmt)
+				expectedCreateDimEdgeStmt := "g.V('_instanceID_Instance').as('inst').V('_instanceID_dimID_option').addE('HAS_DIMENSION').to('inst')"
+				So(poolMock.ExecuteCalls()[1].Query, ShouldEqual, expectedCreateDimEdgeStmt)
+			})
+
+			Convey("Then the new dimension ID is returned", func() {
+				So(err, ShouldBeNil)
+				So(insertedDimension, ShouldNotBeNil)
+				expectedDimID := "_instanceID_dimID_option"
+				So(insertedDimension.NodeID, ShouldEqual, expectedDimID)
+			})
+		})
+	})
 }

--- a/neptune/dimension_test.go
+++ b/neptune/dimension_test.go
@@ -1,0 +1,158 @@
+package neptune
+
+import (
+	"context"
+	"github.com/ONSdigital/dp-graph/v2/models"
+	"github.com/ONSdigital/dp-graph/v2/neptune/internal"
+	"github.com/ONSdigital/graphson"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNeptuneDB_InsertDimension(t *testing.T) {
+
+	ctx := context.Background()
+	instanceID := "instanceID"
+
+	Convey("Given a empty instance ID value", t, func() {
+
+		uniqueDimensions := map[string]string{}
+		dimension := createDimension()
+		db := createMockDB(createVertices())
+		instanceID := ""
+
+		Convey("When InsertDimension is called", func() {
+
+			insertedDimension, err := db.InsertDimension(ctx, uniqueDimensions, instanceID, dimension)
+
+			Convey("Then the expected error is returned", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "instance id is required but was empty")
+				So(insertedDimension, ShouldBeNil)
+			})
+		})
+	})
+
+	Convey("Given a nil dimension value", t, func() {
+		uniqueDimensions := map[string]string{}
+		db := createMockDB(createVertices())
+		var dimension *models.Dimension
+
+		Convey("When InsertDimension is called", func() {
+
+			insertedDimension, err := db.InsertDimension(ctx, uniqueDimensions, instanceID, dimension)
+
+			Convey("Then the expected error is returned", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "dimension is required but was nil")
+				So(insertedDimension, ShouldBeNil)
+			})
+		})
+	})
+
+	Convey("Given an empty dimension ID", t, func() {
+		uniqueDimensions := map[string]string{}
+		dimension := createDimension()
+		db := createMockDB(createVertices())
+
+		dimension.DimensionID = ""
+
+		Convey("When InsertDimension is called", func() {
+			insertedDimension, err := db.InsertDimension(ctx, uniqueDimensions, instanceID, dimension)
+
+			Convey("Then the expected error is returned", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "dimension id is required but was empty")
+				So(insertedDimension, ShouldBeNil)
+			})
+		})
+	})
+
+	Convey("Given an empty dimension option value", t, func() {
+		uniqueDimensions := map[string]string{}
+		dimension := createDimension()
+		db := createMockDB(createVertices())
+
+		dimension.Option = ""
+
+		Convey("When InsertDimension is called", func() {
+			insertedDimension, err := db.InsertDimension(ctx, uniqueDimensions, instanceID, dimension)
+
+			Convey("Then the expected error is returned", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "dimension value is required but was empty")
+				So(insertedDimension, ShouldBeNil)
+			})
+		})
+	})
+
+	Convey("Given an empty dimension ID and option value", t, func() {
+		uniqueDimensions := map[string]string{}
+		dimension := createDimension()
+		db := createMockDB(createVertices())
+
+		dimension.DimensionID = ""
+		dimension.Option = ""
+
+		Convey("When InsertDimension is called", func() {
+			insertedDimension, err := db.InsertDimension(ctx, uniqueDimensions, instanceID, dimension)
+
+			Convey("Then the expected error is returned", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "dimension invalid: both dimension.dimension_id and dimension.value are required but were both empty")
+				So(insertedDimension, ShouldBeNil)
+			})
+		})
+	})
+
+	Convey("Given a dimension to insert", t, func() {
+
+		uniqueDimensions := map[string]string{}
+		dimension := createDimension()
+		expectedVertices := createVertices()
+		db := createMockDB(expectedVertices)
+
+		Convey("When InsertDimension is called", func() {
+
+			insertedDimension, err := db.InsertDimension(ctx, uniqueDimensions, instanceID, dimension)
+
+			Convey("Then the dimension ID is returned", func() {
+				So(err, ShouldBeNil)
+				So(insertedDimension, ShouldNotBeNil)
+				So(insertedDimension.NodeID, ShouldEqual, expectedVertices[0].GetID())
+			})
+		})
+	})
+}
+
+func createMockDB(expectedVertices []graphson.Vertex) *NeptuneDB {
+	poolMock := &internal.NeptunePoolMock{
+		GetFunc: func(query string, bindings map[string]string, rebindings map[string]string) ([]graphson.Vertex, error) {
+			return expectedVertices, nil
+		},
+	}
+	db := mockDB(poolMock)
+	return db
+}
+
+func createDimension() *models.Dimension {
+	return &models.Dimension{
+		DimensionID: "dimID",
+		Option:      "option",
+		NodeID:      "nodeID",
+	}
+}
+
+func createVertices() []graphson.Vertex {
+	expectedVertex := graphson.Vertex{
+		Type: "",
+		Value: graphson.VertexValue{
+			ID:         "123",
+			Label:      "",
+			Properties: nil,
+		},
+	}
+	expectedVertices := []graphson.Vertex{expectedVertex}
+	return expectedVertices
+}

--- a/neptune/observation.go
+++ b/neptune/observation.go
@@ -202,9 +202,7 @@ func (n *NeptuneDB) removeExistingObservations(obsIDs []string) error {
 	queryExistingObservations := fmt.Sprintf(query.GetObservations, `'`+strings.Join(obsIDs, `','`)+`'`)
 	existingObsIDs, err := n.getStringList(queryExistingObservations)
 	if err != nil {
-		if err.Error() != "DeserializeStringListFromBytes: Expected `g:List` type, but got \\\"\\\"" {
-			return err
-		}
+		return err
 	}
 
 	if len(existingObsIDs) > 0 {

--- a/neptune/query/query.go
+++ b/neptune/query/query.go
@@ -138,11 +138,13 @@ const (
 	AddInstanceDimensionsPropertyPart = `.property('dimensions', "%s")`
 
 	// dimension
-	DropDimensionRelationships            = `g.V().hasId('_%s_%s_%s').bothE().drop().iterate();`
-	DropDimension                         = `g.V().hasId('_%s_%s_%s').drop().iterate();`
-	CreateDimensionToInstanceRelationship = `g.V().hasId('_%s_Instance').as('inst')` +
-		`.addV('_%s_%s').as('d').property(id, '_%s_%s_%s').property('value',"%s")` +
-		`.addE('HAS_DIMENSION').to('inst').select('d')`
+	GetDimension               = `g.V('%s').id()`
+	DropDimensionRelationships = `g.V('%s').bothE().drop().iterate();`
+	DropDimension              = `g.V('%s').drop()`
+
+	CreateDimension                       = `g.addV('_%s_%s').property(id, '%s').property('value',"%s")`
+	CreateDimensionToInstanceRelationship = `g.V('_%s_Instance').as('inst')` +
+		`.V('%s').addE('HAS_DIMENSION').to('inst')`
 
 	// observation
 	GetObservations      = `g.V(%s).id()`


### PR DESCRIPTION
### What
Rework the dimension import queries to support concurrency in Neptune. Neptune has an aggressive locking strategy, which produces many "conflict detection" errors when importing datasets. This PR is implementing the advice given from AWS Neptune experts - to separate the read and write parts of the query to minimise the lock contention.

- Add test coverage to existing Neptune `InsertDimension` functionality
- Remove redundant error check (An error is no longer returned for an empty list of results)
- Separate read / write Neptune statements to improve concurrency

### How to review
Review changes / check tests pass

### Who can review
Anyone
