### PR TITLE
Fix query for getting datasets for a code

### DIFF
--- a/neptune/codelistsdataset.go
+++ b/neptune/codelistsdataset.go
@@ -34,9 +34,9 @@ Each such result from the database (potentially) has the properties:
     - datasetEdition
     - version
 
-The results however include all permuations of dimensionName and
+The results however include all permutations of dimensionName and
 datasetEdition - BUT ONLY CITES the most recent dataset *version* of those
-found for that permuation.
+found for that permutation.
 
 */
 func (n *NeptuneDB) GetCodeDatasets(ctx context.Context, codeListID, edition string, code string) (*models.Datasets, error) {
@@ -55,7 +55,7 @@ func (n *NeptuneDB) GetCodeDatasets(ctx context.Context, codeListID, edition str
 		return nil, errors.Wrap(err, "Cannot create records.")
 	}
 
-	// Build datastructure to capture only latest dataset versions.
+	// Build data structure to capture only latest dataset versions.
 	latestVersionMaps, err := buildLatestVersionMaps(responseRecords)
 	if err != nil {
 		return nil, errors.Wrap(err, "Cannot isolate latest versions.")

--- a/neptune/codelistsdataset_test.go
+++ b/neptune/codelistsdataset_test.go
@@ -221,8 +221,8 @@ func TestGetCodeDatasetsAtAPILevel(t *testing.T) {
 							__.as('r').outV().has('value',"unusedCode").as('c'),
 							__.as('c').out('inDataset').as('d').
 								select('d').values('edition').as('de').
-								select('d').values('version').as('dv'),
-								select('d').values('dataset_id').as('did').
+								select('d').values('version').as('dv').
+								select('d').values('dataset_id').as('did'),
 							__.as('d').has('is_published',true)).
 						union(select('rl', 'de', 'dv', 'did')).unfold().select(values)
                     `)

--- a/neptune/query/query.go
+++ b/neptune/query/query.go
@@ -44,8 +44,8 @@ const (
 			__.as('r').outV().has('value',"%s").as('c'),
 			__.as('c').out('inDataset').as('d').
 				select('d').values('edition').as('de').
-				select('d').values('version').as('dv'),
-				select('d').values('dataset_id').as('did').
+				select('d').values('version').as('dv').
+				select('d').values('dataset_id').as('did'),
 			__.as('d').has('is_published',true)).
 		union(select('rl', 'de', 'dv', 'did')).unfold().select(values)
 	`


### PR DESCRIPTION
### What

Fix query for getting datasets for a code. The syntax was incorrect.

### How to review
Review changes + ensure tests pass

An example query you can run against dev-test Neptune instance if you want to try it:

```
g.V().hasLabel('_code_list').has('listID', 'sex').
  has('edition','one-off').
  inE('usedBy').as('r').values('label').as('rl').select('r').
  match(
   __.as('r').outV().has('value',"female").as('c'),
   __.as('c').out('inDataset').as('d').
    select('d').values('edition').as('de').
    select('d').values('version').as('dv').
    select('d').values('dataset_id').as('did'),
   __.as('d').has('is_published',true)).
  union(select('rl', 'de', 'dv', 'did')).unfold().select(values)
```

### Who can review
Anyone
