### PR TITLE
Take retry function from dp-net

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"time"
 
 	"github.com/ONSdigital/dp-graph/v2/graph/driver"
 	"github.com/ONSdigital/dp-graph/v2/mock"
@@ -13,11 +14,12 @@ import (
 // Configuration allows environment variables to be read and sent to the
 // relevant driver for further setup
 type Configuration struct {
-	DriverChoice    string `envconfig:"GRAPH_DRIVER_TYPE"`
-	DatabaseAddress string `envconfig:"GRAPH_ADDR" json:"-"`
-	PoolSize        int    `envconfig:"GRAPH_POOL_SIZE"`
-	MaxRetries      int    `envconfig:"MAX_RETRIES"`
-	QueryTimeout    int    `envconfig:"GRAPH_QUERY_TIMEOUT"`
+	DriverChoice    string        `envconfig:"GRAPH_DRIVER_TYPE"`
+	DatabaseAddress string        `envconfig:"GRAPH_ADDR" json:"-"`
+	PoolSize        int           `envconfig:"GRAPH_POOL_SIZE"`
+	MaxRetries      int           `envconfig:"MAX_RETRIES"`
+	RetryTime       time.Duration `envconfig:"RETRY_TIME"`
+	QueryTimeout    int           `envconfig:"GRAPH_QUERY_TIMEOUT"`
 	Neptune         NeptuneConfig
 
 	Driver driver.Driver
@@ -58,8 +60,16 @@ func Get(errs chan error) (*Configuration, error) {
 			return nil, err
 		}
 	case "neptune":
-		d, err = neptune.New(cfg.DatabaseAddress, cfg.PoolSize, cfg.QueryTimeout, cfg.MaxRetries,
-			cfg.Neptune.BatchSizeReader, cfg.Neptune.BatchSizeWriter, cfg.Neptune.MaxWorkers, errs)
+		d, err = neptune.New(
+			cfg.DatabaseAddress,
+			cfg.PoolSize,
+			cfg.QueryTimeout,
+			cfg.MaxRetries,
+			cfg.Neptune.BatchSizeReader,
+			cfg.Neptune.BatchSizeWriter,
+			cfg.Neptune.MaxWorkers,
+			cfg.RetryTime,
+			errs)
 		if err != nil {
 			return nil, err
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestGetFailsByDefault(t *testing.T) {
 	Convey("When configuration not provided, fail by default", t, func() {
+		os.Clearenv()
 		cfg = nil
 		cfg, err := Get(nil)
 		So(err, ShouldNotBeNil)

--- a/neptune/mockedneptune.go
+++ b/neptune/mockedneptune.go
@@ -3,6 +3,7 @@ package neptune
 import (
 	"github.com/ONSdigital/dp-graph/v2/neptune/driver"
 	"github.com/ONSdigital/dp-graph/v2/neptune/internal"
+	"time"
 )
 
 // mockDB provides a NeptuneDB, into which you can pass a mocked
@@ -10,6 +11,6 @@ import (
 // database communication.
 func mockDB(poolMock *internal.NeptunePoolMock) *NeptuneDB {
 	driver := driver.NeptuneDriver{Pool: poolMock}
-	db := &NeptuneDB{driver, 5, 30, 25000, 150, 150}
+	db := &NeptuneDB{driver, 5, time.Millisecond, 30, 25000, 150, 150}
 	return db
 }

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -1,0 +1,98 @@
+package retry
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"time"
+)
+
+// Doer provides the function signature for the function that is retried if needed
+type Doer = func() (interface{}, error)
+
+// WantRetry provides the function signature for a custom function to determine if the doer function is retried,
+// based on the returned error
+type WantRetry = func(err error) bool
+
+// ErrAttemptsExceededLimit is returned when the number of attempts has reached
+// the maximum permitted
+type ErrAttemptsExceededLimit struct {
+	WrappedErr error
+}
+
+// Error provides the formatted error string for the ErrAttemptsExceededLimit type
+func (e ErrAttemptsExceededLimit) Error() string {
+	return fmt.Sprintf("number of attempts exceeded: %s", e.WrappedErr.Error())
+}
+
+// Do executes the doer function, and retries if needed up to maxAttempts
+//   ctx - the context that if cancelled with prevent any more retry attempts
+//   doer - the function that is executed and retried if needed
+//   wantRetry - the function that determines if the doer is retried based on the returned error
+//   maxAttempts - the maximum number of times the doer function will be attempted
+//   retryTime - the initial sleep time between requests. The retryTime will exponentially increase on subsequent retries
+func Do(
+	ctx context.Context,
+	doer Doer,
+	wantRetry WantRetry,
+	maxAttempts int,
+	retryTime time.Duration,
+) (res interface{}, err error) {
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+
+		// prioritise any context cancellation
+		if ctx.Err() != nil {
+			err = ctx.Err()
+			return
+		}
+
+		if attempt > 1 {
+			err = sleep(ctx, attempt, retryTime)
+			if err != nil {
+				return
+			}
+		}
+
+		res, err = doer()
+		if err == nil {
+			return // success
+		}
+
+		if !wantRetry(err) {
+			return
+		}
+	}
+
+	return nil, ErrAttemptsExceededLimit{err}
+}
+
+// sleep waits for a calculated time. The time increases based on the attempt number. The function returns
+// immediately if the given context is cancelled.
+func sleep(ctx context.Context, attempt int, retryTime time.Duration) error {
+	pingChan := make(chan struct{}, 0)
+
+	go func() {
+		time.Sleep(getSleepTime(attempt, retryTime))
+		close(pingChan)
+	}()
+
+	// check for first of: context cancellation or sleep ends
+	select {
+	case <-pingChan:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return nil
+}
+
+// getSleepTime calculates a time which increases, based on the attempt and initial retry time.
+// It uses the algorithm 2^n where n is the attempt number (double the previous) and
+// a randomization factor of between 0-5ms so that the server isn't being hit constantly
+// at the same time by many clients
+func getSleepTime(attempt int, retryTime time.Duration) time.Duration {
+	n := math.Pow(2, float64(attempt))
+	rnd := time.Duration(rand.Intn(4)+1) * time.Millisecond
+	return (time.Duration(n) * retryTime) - rnd
+}

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -1,0 +1,100 @@
+package retry_test
+
+import (
+	"context"
+	"github.com/pkg/errors"
+	"testing"
+	"time"
+
+	"github.com/ONSdigital/dp-graph/v2/retry"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func Test_Do(t *testing.T) {
+
+	ctx := context.Background()
+
+	Convey("Given a Doer function that succeeds", t, func() {
+
+		expectedRes := 123
+		doerCallCount := 0
+		maxAttempts := 1
+		retryTime := time.Millisecond
+
+		doer := func() (interface{}, error) {
+			doerCallCount++
+			return expectedRes, nil
+		}
+		wantRetry := func(err error) bool {
+			return false
+		}
+
+		Convey("When do is called", func() {
+
+			res, err := retry.Do(ctx, doer, wantRetry, maxAttempts, retryTime)
+
+			Convey("Then the response from the doer function is returned", func() {
+				So(doerCallCount, ShouldEqual, 1)
+				So(res, ShouldEqual, expectedRes)
+				So(err, ShouldBeNil)
+			})
+		})
+	})
+
+	Convey("Given a doer function that fails", t, func() {
+
+		expectedErr := errors.New("error test message")
+		doerCallCount := 0
+		maxAttempts := 3
+		retryTime := time.Millisecond * 0
+
+		doer := func() (interface{}, error) {
+			doerCallCount++
+			return nil, expectedErr
+		}
+		wantRetry := func(err error) bool {
+			return true
+		}
+
+		Convey("When do is called", func() {
+
+			res, err := retry.Do(ctx, doer, wantRetry, maxAttempts, retryTime)
+
+			Convey("Then the doer is retried the expected number of times", func() {
+				So(doerCallCount, ShouldEqual, 3)
+				So(err.Error(), ShouldEqual, "number of attempts exceeded: "+expectedErr.Error())
+				So(res, ShouldBeNil)
+			})
+		})
+	})
+
+	Convey("Given a cancelled context", t, func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		expectedErr := errors.New("error test message")
+		doerCallCount := 0
+		maxAttempts := 3
+		retryTime := time.Millisecond * 0
+
+		doer := func() (interface{}, error) {
+			doerCallCount++
+			return nil, expectedErr
+		}
+		wantRetry := func(err error) bool {
+			return true
+		}
+
+		Convey("When do is called", func() {
+
+			res, err := retry.Do(ctx, doer, wantRetry, maxAttempts, retryTime)
+
+			Convey("Then the doer is not retried due to the cancelled context", func() {
+				So(doerCallCount, ShouldEqual, 0)
+				So(err.Error(), ShouldEqual, "context canceled")
+				So(res, ShouldBeNil)
+			})
+		})
+	})
+}


### PR DESCRIPTION
### What
Take retry function from dp-net, with some tweaks
- use a common retry function across Neptune functions
- make retryTime configurable, allowing a more aggressive backoff if required
- retry function from dp-net supports cancelled contexts

### How to review
- See if code changes make sense
- Consider if its worth having a common retry function, at the expense of having to cast the results to their required type. (this was being done in some functions before, but not all)
- Check tests pass

### Who can review
Anyone
