### PR TITLE
Feature/sort code lists by order

### DIFF
--- a/graph/driver/driver.go
+++ b/graph/driver/driver.go
@@ -21,7 +21,8 @@ type CodeList interface {
 	GetCodeList(ctx context.Context, codeListID string) (*models.CodeList, error)
 	GetEditions(ctx context.Context, codeListID string) (*models.Editions, error)
 	GetEdition(ctx context.Context, codeListID, edition string) (*models.Edition, error)
-	GetCodes(ctx context.Context, codeListID, edition string) (*models.CodeResults, error)
+	CountCodes(ctx context.Context, codeListID string, edition string) (int64, error)
+	GetCodes(ctx context.Context, codeListID, edition string, offset, limit int) (*models.CodeResults, error)
 	GetCode(ctx context.Context, codeListID, edition string, code string) (*models.Code, error)
 	GetCodeDatasets(ctx context.Context, codeListID, edition string, code string) (*models.Datasets, error)
 }

--- a/graph/driver/driver.go
+++ b/graph/driver/driver.go
@@ -22,7 +22,7 @@ type CodeList interface {
 	GetEditions(ctx context.Context, codeListID string) (*models.Editions, error)
 	GetEdition(ctx context.Context, codeListID, edition string) (*models.Edition, error)
 	CountCodes(ctx context.Context, codeListID string, edition string) (int64, error)
-	GetCodes(ctx context.Context, codeListID, edition string, offset, limit int) (*models.CodeResults, error)
+	GetCodes(ctx context.Context, codeListID, edition string) (*models.CodeResults, error)
 	GetCode(ctx context.Context, codeListID, edition string, code string) (*models.Code, error)
 	GetCodeDatasets(ctx context.Context, codeListID, edition string, code string) (*models.Datasets, error)
 }

--- a/mock/codelists.go
+++ b/mock/codelists.go
@@ -75,7 +75,7 @@ func (m *Mock) CountCodes(ctx context.Context, codeListID string, edition string
 	return 1, nil
 }
 
-func (m *Mock) GetCodes(ctx context.Context, codeListID, edition string, offset, limit int) (*models.CodeResults, error) {
+func (m *Mock) GetCodes(ctx context.Context, codeListID, edition string) (*models.CodeResults, error) {
 	if err := m.checkForErrors(); err != nil {
 		return nil, err
 	}

--- a/mock/codelists.go
+++ b/mock/codelists.go
@@ -71,7 +71,11 @@ func (m *Mock) GetEdition(ctx context.Context, codeListID, edition string) (*mod
 	}, nil
 }
 
-func (m *Mock) GetCodes(ctx context.Context, codeListID, edition string) (*models.CodeResults, error) {
+func (m *Mock) CountCodes(ctx context.Context, codeListID string, edition string) (int64, error) {
+	return 1, nil
+}
+
+func (m *Mock) GetCodes(ctx context.Context, codeListID, edition string, offset, limit int) (*models.CodeResults, error) {
 	if err := m.checkForErrors(); err != nil {
 		return nil, err
 	}

--- a/neo4j/codelists.go
+++ b/neo4j/codelists.go
@@ -82,7 +82,7 @@ func (n *Neo4j) CountCodes(ctx context.Context, codeListID, edition string) (int
 }
 
 // GetCodes returns a list of codes for a specified edition of a code list
-func (n *Neo4j) GetCodes(ctx context.Context, codeListID, editionID string, offset, limit int) (*models.CodeResults, error) {
+func (n *Neo4j) GetCodes(ctx context.Context, codeListID, editionID string) (*models.CodeResults, error) {
 	log.Event(ctx, "about to query neo4j for codes", log.INFO, log.Data{"code_list_id": codeListID, "edition": editionID})
 
 	exists, err := n.GetEdition(ctx, codeListID, editionID)

--- a/neo4j/codelists.go
+++ b/neo4j/codelists.go
@@ -77,8 +77,12 @@ func (n *Neo4j) GetEdition(ctx context.Context, codeListID, editionID string) (*
 	return edition, nil
 }
 
+func (n *Neo4j) CountCodes(ctx context.Context, codeListID, edition string) (int64, error) {
+	return 0, driver.ErrNotImplemented
+}
+
 // GetCodes returns a list of codes for a specified edition of a code list
-func (n *Neo4j) GetCodes(ctx context.Context, codeListID, editionID string) (*models.CodeResults, error) {
+func (n *Neo4j) GetCodes(ctx context.Context, codeListID, editionID string, offset, limit int) (*models.CodeResults, error) {
 	log.Event(ctx, "about to query neo4j for codes", log.INFO, log.Data{"code_list_id": codeListID, "edition": editionID})
 
 	exists, err := n.GetEdition(ctx, codeListID, editionID)

--- a/neptune/codelist.go
+++ b/neptune/codelist.go
@@ -168,7 +168,7 @@ query).  It raises driver.ErrNotFound if the graph traversal above produces an e
 including the case of a short-circuit early termination of the query, because no such qualifying code
 list exists. It returns a wrapped error if a Code is found that does not have a "value" property.
 */
-func (n *NeptuneDB) GetCodes(ctx context.Context, codeListID, edition string, offset, limit int) (*models.CodeResults, error) {
+func (n *NeptuneDB) GetCodes(ctx context.Context, codeListID, edition string) (*models.CodeResults, error) {
 
 	// Check if order is defined
 	qry := fmt.Sprintf(query.CountOrderedEdges, codeListID, edition)

--- a/neptune/codelists_test.go
+++ b/neptune/codelists_test.go
@@ -329,8 +329,6 @@ func TestCountCodes(t *testing.T) {
 }
 
 func TestGetCodes(t *testing.T) {
-	offset := 0
-	limit := 20
 	unusedCodeListID := "unused-id"
 	unusedEdition := "unused-edition"
 
@@ -340,7 +338,7 @@ func TestGetCodes(t *testing.T) {
 		}
 		db := mockDB(poolMock)
 		Convey("When GetCodes() is called", func() {
-			_, err := db.GetCodes(context.Background(), unusedCodeListID, unusedEdition, offset, limit)
+			_, err := db.GetCodes(context.Background(), unusedCodeListID, unusedEdition)
 			expectedErr := `Gremlin query failed: "g.V().has('_code_list','listID', 'unused-id').has('edition', 'unused-edition').` +
 				`inE('usedBy').has('order').count()":  MALFORMED REQUEST `
 			Convey("Then the returned error should wrap the underlying one", func() {
@@ -356,7 +354,7 @@ func TestGetCodes(t *testing.T) {
 		}
 		db := mockDB(poolMock)
 		Convey("When GetCodes() is called", func() {
-			_, err := db.GetCodes(context.Background(), unusedCodeListID, unusedEdition, offset, limit)
+			_, err := db.GetCodes(context.Background(), unusedCodeListID, unusedEdition)
 			expectedErr := `Gremlin query failed: "g.V().has('_code_list','listID', 'unused-id').has('edition', 'unused-edition').` +
 				`inE('usedBy').as('usedBy').outV().order().by('value',incr).as('code').select('usedBy', 'code').by('label').by('value').` +
 				`unfold().select(values)":  MALFORMED REQUEST `
@@ -373,7 +371,7 @@ func TestGetCodes(t *testing.T) {
 		}
 		db := mockDB(poolMock)
 		Convey("When GetCodes() is called", func() {
-			_, err := db.GetCodes(context.Background(), unusedCodeListID, unusedEdition, offset, limit)
+			_, err := db.GetCodes(context.Background(), unusedCodeListID, unusedEdition)
 			expectedErr := `Gremlin query failed: "g.V().has('_code_list', 'listID', 'unused-id').has('edition', 'unused-edition').` +
 				`inE('usedBy').order().by('order',incr).as('usedBy').outV().as('code').select('usedBy', 'code').by('label').by('value').` +
 				`unfold().select(values)":  MALFORMED REQUEST `
@@ -390,7 +388,7 @@ func TestGetCodes(t *testing.T) {
 		}
 		db := mockDB(poolMock)
 		Convey("When GetCodes() is called", func() {
-			_, err := db.GetCodes(context.Background(), unusedCodeListID, unusedEdition, offset, limit)
+			_, err := db.GetCodes(context.Background(), unusedCodeListID, unusedEdition)
 			Convey("Then the returned error should be ErrNotFound", func() {
 				So(err, ShouldEqual, driver.ErrNotFound)
 			})
@@ -404,7 +402,7 @@ func TestGetCodes(t *testing.T) {
 		}
 		db := mockDB(poolMock)
 		Convey("When GetCodes() is called", func() {
-			_, err := db.GetCodes(context.Background(), unusedCodeListID, unusedEdition, offset, limit)
+			_, err := db.GetCodes(context.Background(), unusedCodeListID, unusedEdition)
 			expectedErr := `list length is not divisible by 2`
 			Convey("Then the returned error should wrap the underlying one", func() {
 				So(err.Error(), ShouldEqual, expectedErr)
@@ -419,7 +417,7 @@ func TestGetCodes(t *testing.T) {
 		}
 		db := mockDB(poolMock)
 		Convey("When GetCodes() is called", func() {
-			codesResponse, err := db.GetCodes(context.Background(), unusedCodeListID, unusedEdition, offset, limit)
+			codesResponse, err := db.GetCodes(context.Background(), unusedCodeListID, unusedEdition)
 			Convey("Then no error should be returned", func() {
 				So(err, ShouldBeNil)
 			})
@@ -454,7 +452,7 @@ func TestGetCodes(t *testing.T) {
 		}
 		db := mockDB(poolMock)
 		Convey("When GetCodes() is called", func() {
-			codesResponse, err := db.GetCodes(context.Background(), unusedCodeListID, unusedEdition, offset, limit)
+			codesResponse, err := db.GetCodes(context.Background(), unusedCodeListID, unusedEdition)
 			Convey("Then no error should be returned", func() {
 				So(err, ShouldBeNil)
 			})

--- a/neptune/internal/mockpoolutils.go
+++ b/neptune/internal/mockpoolutils.go
@@ -25,6 +25,12 @@ var ReturnTwo = func(q string, bindings, rebindings map[string]string) (i int64,
 	return 2, nil
 }
 
+// ReturnThree is a mock implementation for NeptunePool.GetCount()
+// that always returns a count of 3.
+var ReturnThree = func(q string, bindings, rebindings map[string]string) (i int64, err error) {
+	return 3, nil
+}
+
 // ReturnZero is a mock implementation for NeptunePool.GetCount()
 // that always returns a count of 0.
 var ReturnZero = func(q string, bindings, rebindings map[string]string) (i int64, err error) {

--- a/neptune/query/query.go
+++ b/neptune/query/query.go
@@ -12,8 +12,16 @@ const (
 	GetCodeList           = `g.V().hasLabel('_code_list').has('listID', '%s')`
 	CodeListExists        = `g.V().hasLabel('_code_list').has('listID', '%s').count()`
 	CodeListEditionExists = `g.V().hasLabel('_code_list').has('listID', '%s').has('edition', '%s').count()`
-	GetCodes              = `g.V().has('_code_list','listID', '%s').has('edition', '%s')` +
-		`.inE("usedBy").as('usedBy')` +
+	CountCodes            = `g.V().has('_code_list','listID', '%s').has('edition', '%s')` +
+		`.in('usedBy').count()`
+	CountOrderedEdges      = `g.V().has('_code_list','listID', '%s').has('edition', '%s').inE('usedBy').has('order').count()`
+	GetCodesAlphabetically = `g.V().has('_code_list','listID', '%s').has('edition', '%s')` +
+		`.inE('usedBy').as('usedBy')` +
+		`.outV().order().by('value',incr).as('code')` +
+		`.select('usedBy', 'code').by('label').by('value')` +
+		`.unfold().select(values)`
+	GetCodesWithOrder = `g.V().has('_code_list', 'listID', '%s').has('edition', '%s')` +
+		`.inE('usedBy').order().by('order',incr).as('usedBy')` +
 		`.outV().as('code')` +
 		`.select('usedBy', 'code').by('label').by('value')` +
 		`.unfold().select(values)`


### PR DESCRIPTION
### What

- Added `CountCodes` method, so that we don't need to traverse all the codes if the caller is just interested in the count.
- `GetCodes` now returns sorted codes:
  -  If `UsedBy` edges contain `order` property, then this is used to determine the order
  - Otherwise, the codes are sorted alphabetically by code.
- Changed and added unit tests accordingly

### How to review

- Make sure code changes make sense
- Make sure unit tests pass
- (info only) I manually tested these changes by using them in the codelist API

### Who can review

Anyone