### PR TITLE
Get code order for a codeList from `usedBy` edge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,16 @@
+.PHONY: all
+all: audit test build
+
+.PHONY: audit
+audit:
+	go list -m all | nancy sleuth
+
+.PHONY: test
 test:
 	go test -count=1 -race -cover ./...
-.PHONY: test
+
+.PHONY: build
+build:
+	go test -count=1 -race -cover ./...
+
+.PHONY: build debug test

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,3 @@
-.PHONY: all
-all: audit test build
-
-.PHONY: audit
-audit:
-	go list -m all | nancy sleuth
-
-.PHONY: test
 test:
 	go test -count=1 -race -cover ./...
-
-.PHONY: build
-build:
-	go test -count=1 -race -cover ./...
-
-.PHONY: build debug test
+.PHONY: test

--- a/graph/driver/driver.go
+++ b/graph/driver/driver.go
@@ -25,6 +25,7 @@ type CodeList interface {
 	GetCodes(ctx context.Context, codeListID, edition string) (*models.CodeResults, error)
 	GetCode(ctx context.Context, codeListID, edition string, code string) (*models.Code, error)
 	GetCodeDatasets(ctx context.Context, codeListID, edition string, code string) (*models.Datasets, error)
+	GetCodeOrder(ctx context.Context, codeListID, code string) (order *int, err error)
 }
 
 // Hierarchy defines functions to create and retrieve generic and instance hierarchy nodes

--- a/mock/codelists.go
+++ b/mock/codelists.go
@@ -93,6 +93,13 @@ func (m *Mock) GetCode(ctx context.Context, codeListID, edition string, code str
 	return &models.Code{}, nil
 }
 
+func (m *Mock) GetCodeOrder(ctx context.Context, codeListID, code string) (order *int, err error) {
+	if err := m.checkForErrors(); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
 func (m *Mock) GetCodeDatasets(ctx context.Context, codeListID, edition string, code string) (*models.Datasets, error) {
 	if err := m.checkForErrors(); err != nil {
 		return nil, err

--- a/neo4j/codelists.go
+++ b/neo4j/codelists.go
@@ -117,6 +117,11 @@ func (n *Neo4j) GetCode(ctx context.Context, codeListID, editionID string, codeI
 	return code, nil
 }
 
+// GetCodeOrder is not implemented
+func (n *Neo4j) GetCodeOrder(ctx context.Context, codeListID, code string) (order *int, err error) {
+	return nil, driver.ErrNotImplemented
+}
+
 // GetCodeDatasets returns a list of datasets where the code is used
 func (n *Neo4j) GetCodeDatasets(ctx context.Context, codeListID, edition string, code string) (*models.Datasets, error) {
 	log.Event(ctx, "about to query neo4j for datasets by code", log.INFO, log.Data{"code_list_id": codeListID, "edition": edition, "code": code})

--- a/neptune/codelists_test.go
+++ b/neptune/codelists_test.go
@@ -2,12 +2,15 @@ package neptune
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
+	"github.com/pkg/errors"
 	. "github.com/smartystreets/goconvey/convey"
 
 	"github.com/ONSdigital/dp-graph/v2/graph/driver"
 	"github.com/ONSdigital/dp-graph/v2/neptune/internal"
+	"github.com/ONSdigital/graphson"
 )
 
 func TestGetCodeLists(t *testing.T) {
@@ -553,6 +556,196 @@ func TestGetCode(t *testing.T) {
 			Convey("Then the returned error should should object to there being multiple", func() {
 				So(err, ShouldNotBeNil)
 				So(err, ShouldEqual, driver.ErrMultipleFound)
+			})
+		})
+	})
+}
+
+func TestGetCodeOrder(t *testing.T) {
+
+	testCodeListID := "mmm"
+	testCode := "mar"
+
+	Convey("Given a database containing valid 'usedBy' edge with order", t, func() {
+		expectedOrder := PropertyValueInt{
+			Value: 2,
+		}
+
+		orderValue, err := json.Marshal(&expectedOrder)
+		So(err, ShouldBeNil)
+
+		poolMock := &internal.NeptunePoolMock{
+			GetEFunc: func(q string, bindings map[string]string, rebindings map[string]string) (interface{}, error) {
+				return []graphson.Edge{
+					{
+						Type: "g:Edge",
+						Value: graphson.EdgeValue{
+							Label: "usedBy",
+							Properties: map[string]graphson.EdgeProperty{
+								"order": {
+									Type: "g.Property",
+									Value: graphson.EdgePropertyValue{
+										Label: "order",
+										Value: orderValue,
+									},
+								},
+							},
+						},
+					},
+				}, nil
+			},
+		}
+		db := mockDB(poolMock)
+
+		Convey("When GetCodeOrder() is called", func() {
+			order, err := db.GetCodeOrder(context.Background(), testCodeListID, testCode)
+
+			Convey("Then the expected order should be returned withour error", func() {
+				So(err, ShouldBeNil)
+				So(*order, ShouldEqual, expectedOrder.Value)
+			})
+
+			Convey("Then the driver GetE function should be called once with the expected query", func() {
+				expectedQry := `g.V().hasId('_code_mmm_mar')` +
+					`.outE('usedBy')` +
+					`.where(otherV().hasLabel('_code_list').has('_code_list', 'listID', 'mmm'))`
+				So(poolMock.GetECalls(), ShouldHaveLength, 1)
+				So(poolMock.GetECalls()[0].Q, ShouldEqual, expectedQry)
+			})
+		})
+	})
+
+	Convey("Given a database containing valid 'usedBy' edge without order", t, func() {
+		poolMock := &internal.NeptunePoolMock{
+			GetEFunc: func(q string, bindings map[string]string, rebindings map[string]string) (interface{}, error) {
+				return []graphson.Edge{
+					{
+						Type: "g:Edge",
+						Value: graphson.EdgeValue{
+							Label:      "usedBy",
+							Properties: map[string]graphson.EdgeProperty{},
+						},
+					},
+				}, nil
+			},
+		}
+		db := mockDB(poolMock)
+
+		Convey("When GetCodeOrder() is called", func() {
+			order, err := db.GetCodeOrder(context.Background(), testCodeListID, testCode)
+
+			Convey("Then a nil order should be returned withour error", func() {
+				So(err, ShouldBeNil)
+				So(order, ShouldBeNil)
+			})
+
+			Convey("Then the driver GetE function should be called once with the expected query", func() {
+				expectedQry := `g.V().hasId('_code_mmm_mar')` +
+					`.outE('usedBy')` +
+					`.where(otherV().hasLabel('_code_list').has('_code_list', 'listID', 'mmm'))`
+				So(poolMock.GetECalls(), ShouldHaveLength, 1)
+				So(poolMock.GetECalls()[0].Q, ShouldEqual, expectedQry)
+			})
+		})
+	})
+
+	Convey("Given a database that fails to get get edges", t, func() {
+		errGetE := errors.New("getE failed")
+		poolMock := &internal.NeptunePoolMock{
+			GetEFunc: func(q string, bindings map[string]string, rebindings map[string]string) (interface{}, error) {
+				return []graphson.Edge{}, errGetE
+			},
+		}
+		db := mockDB(poolMock)
+
+		Convey("When GetCodeOrder() is called", func() {
+			_, err := db.GetCodeOrder(context.Background(), testCodeListID, testCode)
+
+			Convey("Then the wrapped error should be returned", func() {
+				expectedErr := "Gremlin query failed: \"g.V().hasId('_code_mmm_mar').outE('usedBy').where(otherV().hasLabel('_code_list').has('_code_list', 'listID', 'mmm'))\": number of attempts exceeded: getE failed"
+				So(err.Error(), ShouldResemble, expectedErr)
+			})
+		})
+	})
+
+	Convey("Given a database that does not return any 'usedBy' edge", t, func() {
+		poolMock := &internal.NeptunePoolMock{
+			GetEFunc: func(q string, bindings map[string]string, rebindings map[string]string) (interface{}, error) {
+				return []graphson.Edge{}, nil
+			},
+		}
+		db := mockDB(poolMock)
+
+		Convey("When GetCodeOrder() is called", func() {
+			_, err := db.GetCodeOrder(context.Background(), testCodeListID, testCode)
+
+			Convey("Then a notFound error should be returned", func() {
+				So(err, ShouldResemble, driver.ErrNotFound)
+			})
+		})
+	})
+
+	Convey("Given a database containing multiple 'usedBy' edges for the same code-codelist pair", t, func() {
+		poolMock := &internal.NeptunePoolMock{
+			GetEFunc: func(q string, bindings map[string]string, rebindings map[string]string) (interface{}, error) {
+				return []graphson.Edge{
+					{
+						Type: "g:Edge",
+						Value: graphson.EdgeValue{
+							Label:      "usedBy",
+							Properties: map[string]graphson.EdgeProperty{},
+						},
+					},
+					{
+						Type: "g:Edge",
+						Value: graphson.EdgeValue{
+							Label:      "usedBy",
+							Properties: map[string]graphson.EdgeProperty{},
+						},
+					},
+				}, nil
+			},
+		}
+		db := mockDB(poolMock)
+
+		Convey("When GetCodeOrder() is called", func() {
+			_, err := db.GetCodeOrder(context.Background(), testCodeListID, testCode)
+
+			Convey("Then a multipleFound error should be returned", func() {
+				So(err, ShouldResemble, driver.ErrMultipleFound)
+			})
+		})
+	})
+
+	Convey("Given a database containing a 'usedBy' edge with invalid order value", t, func() {
+		poolMock := &internal.NeptunePoolMock{
+			GetEFunc: func(q string, bindings map[string]string, rebindings map[string]string) (interface{}, error) {
+				return []graphson.Edge{
+					{
+						Type: "g:Edge",
+						Value: graphson.EdgeValue{
+							Label: "usedBy",
+							Properties: map[string]graphson.EdgeProperty{
+								"order": {
+									Type: "g.Property",
+									Value: graphson.EdgePropertyValue{
+										Label: "order",
+										Value: []byte{1, 2, 3, 4, 5},
+									},
+								},
+							},
+						},
+					},
+				}, nil
+			},
+		}
+		db := mockDB(poolMock)
+
+		Convey("When GetCodeOrder() is called", func() {
+			_, err := db.GetCodeOrder(context.Background(), testCodeListID, testCode)
+
+			Convey("Then the expected unmarshal order should be returned", func() {
+				So(err.Error(), ShouldResemble, "invalid character '\\x01' looking for beginning of value")
 			})
 		})
 	})

--- a/neptune/codelists_test.go
+++ b/neptune/codelists_test.go
@@ -649,7 +649,7 @@ func TestGetCodeOrder(t *testing.T) {
 		})
 	})
 
-	Convey("Given a database that fails to get get edges", t, func() {
+	Convey("Given a database that fails to get edges", t, func() {
 		errGetE := errors.New("getE failed")
 		poolMock := &internal.NeptunePoolMock{
 			GetEFunc: func(q string, bindings map[string]string, rebindings map[string]string) (interface{}, error) {

--- a/neptune/neptune.go
+++ b/neptune/neptune.go
@@ -3,14 +3,13 @@ package neptune
 import (
 	"context"
 	"errors"
-	"github.com/ONSdigital/dp-graph/v2/retry"
 	"math/rand"
 	"strings"
 	"time"
 
 	"github.com/ONSdigital/dp-graph/v2/graph/driver"
-
 	neptune "github.com/ONSdigital/dp-graph/v2/neptune/driver"
+	"github.com/ONSdigital/dp-graph/v2/retry"
 	"github.com/ONSdigital/graphson"
 	gremgo "github.com/ONSdigital/gremgo-neptune"
 	"github.com/ONSdigital/log.go/log"
@@ -133,6 +132,11 @@ func (n *NeptuneDB) getVertex(gremStmt string) (vertex graphson.Vertex, err erro
 		return
 	}
 	return vertices[0], nil
+}
+
+// PropertyValueInt represents an edge property value of type int
+type PropertyValueInt struct {
+	Value int `json:"@value"`
 }
 
 func (n *NeptuneDB) getEdges(gremStmt string) (edges []graphson.Edge, err error) {

--- a/neptune/query/query.go
+++ b/neptune/query/query.go
@@ -28,6 +28,9 @@ const (
 	CodeExists = `g.V().hasLabel('_code_list')` +
 		`.has('listID', '%s').has('edition', '%s')` +
 		`.in('usedBy').has('value', "%s").count()`
+	GetUsedByEdge = `g.V().hasId('_code_%s_%s')` +
+		`.outE('usedBy')` +
+		`.where(otherV().hasLabel('_code_list').has('_code_list', 'listID', '%s'))`
 
 	/*
 		This query harvests data from both edges and nodes, so we collapse


### PR DESCRIPTION
### What

This change will be used by the dimension importer, in order to obtain the order for a dimension option.

- Added `GetCodeOrder` method to obtain the numerical order of a code for a codelist. (implemented by Neptune only)
- Fixed mock and Neo4J to implement the method (neo4J returns ErrNotImplemented)
- Added PropertyValueInt type, so that we can unmarshal the `order` property to an int value
- Added unit tests (validated with a real connection to develop Neptune cluster before creating the mocks)

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

### Who can review

Anyone