### PR TITLE
fixed GetUsedByEdge query to use code label instead of code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ONSdigital/dp-graph/v2
 
-go 1.13
+go 1.16
 
 require (
 	github.com/ONSdigital/dp-healthcheck v1.0.5

--- a/graph/driver/driver.go
+++ b/graph/driver/driver.go
@@ -25,7 +25,7 @@ type CodeList interface {
 	GetCodes(ctx context.Context, codeListID, edition string) (*models.CodeResults, error)
 	GetCode(ctx context.Context, codeListID, edition string, code string) (*models.Code, error)
 	GetCodeDatasets(ctx context.Context, codeListID, edition string, code string) (*models.Datasets, error)
-	GetCodeOrder(ctx context.Context, codeListID, code string) (order *int, err error)
+	GetCodeOrder(ctx context.Context, codeListID, codeLabel string) (order *int, err error)
 }
 
 // Hierarchy defines functions to create and retrieve generic and instance hierarchy nodes

--- a/mock/codelists.go
+++ b/mock/codelists.go
@@ -93,7 +93,7 @@ func (m *Mock) GetCode(ctx context.Context, codeListID, edition string, code str
 	return &models.Code{}, nil
 }
 
-func (m *Mock) GetCodeOrder(ctx context.Context, codeListID, code string) (order *int, err error) {
+func (m *Mock) GetCodeOrder(ctx context.Context, codeListID, codeLabel string) (order *int, err error) {
 	if err := m.checkForErrors(); err != nil {
 		return nil, err
 	}

--- a/neo4j/codelists.go
+++ b/neo4j/codelists.go
@@ -118,7 +118,7 @@ func (n *Neo4j) GetCode(ctx context.Context, codeListID, editionID string, codeI
 }
 
 // GetCodeOrder is not implemented
-func (n *Neo4j) GetCodeOrder(ctx context.Context, codeListID, code string) (order *int, err error) {
+func (n *Neo4j) GetCodeOrder(ctx context.Context, codeListID, codeLabel string) (order *int, err error) {
 	return nil, driver.ErrNotImplemented
 }
 

--- a/neptune/codelist.go
+++ b/neptune/codelist.go
@@ -250,8 +250,8 @@ func (n *NeptuneDB) GetCode(ctx context.Context, codeListID, edition string, cod
 }
 
 // GetCodeOrder obtains the numerical order value defined in the 'usedBy' edge between the provided code and codeListID
-func (n *NeptuneDB) GetCodeOrder(ctx context.Context, codeListID, code string) (order *int, err error) {
-	qry := fmt.Sprintf(query.GetUsedByEdge, codeListID, code, codeListID)
+func (n *NeptuneDB) GetCodeOrder(ctx context.Context, codeListID, codeLabel string) (order *int, err error) {
+	qry := fmt.Sprintf(query.GetUsedByEdge, codeListID, codeLabel)
 	res, err := n.getEdges(qry)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Gremlin query failed: %q", qry)

--- a/neptune/codelists_test.go
+++ b/neptune/codelists_test.go
@@ -563,8 +563,8 @@ func TestGetCode(t *testing.T) {
 
 func TestGetCodeOrder(t *testing.T) {
 
-	testCodeListID := "mmm"
-	testCode := "mar"
+	testCodeListID := "yyyy-qq"
+	testCodeLabel := "2016 Q1"
 
 	Convey("Given a database containing valid 'usedBy' edge with order", t, func() {
 		expectedOrder := PropertyValueInt{
@@ -598,7 +598,7 @@ func TestGetCodeOrder(t *testing.T) {
 		db := mockDB(poolMock)
 
 		Convey("When GetCodeOrder() is called", func() {
-			order, err := db.GetCodeOrder(context.Background(), testCodeListID, testCode)
+			order, err := db.GetCodeOrder(context.Background(), testCodeListID, testCodeLabel)
 
 			Convey("Then the expected order should be returned withour error", func() {
 				So(err, ShouldBeNil)
@@ -606,9 +606,7 @@ func TestGetCodeOrder(t *testing.T) {
 			})
 
 			Convey("Then the driver GetE function should be called once with the expected query", func() {
-				expectedQry := `g.V().hasId('_code_mmm_mar')` +
-					`.outE('usedBy')` +
-					`.where(otherV().hasLabel('_code_list').has('_code_list', 'listID', 'mmm'))`
+				expectedQry := `g.V().hasLabel('_code_list').has('_code_list', 'listID', 'yyyy-qq').inE('usedBy').has('label', '2016 Q1')`
 				So(poolMock.GetECalls(), ShouldHaveLength, 1)
 				So(poolMock.GetECalls()[0].Q, ShouldEqual, expectedQry)
 			})
@@ -632,7 +630,7 @@ func TestGetCodeOrder(t *testing.T) {
 		db := mockDB(poolMock)
 
 		Convey("When GetCodeOrder() is called", func() {
-			order, err := db.GetCodeOrder(context.Background(), testCodeListID, testCode)
+			order, err := db.GetCodeOrder(context.Background(), testCodeListID, testCodeLabel)
 
 			Convey("Then a nil order should be returned withour error", func() {
 				So(err, ShouldBeNil)
@@ -640,9 +638,7 @@ func TestGetCodeOrder(t *testing.T) {
 			})
 
 			Convey("Then the driver GetE function should be called once with the expected query", func() {
-				expectedQry := `g.V().hasId('_code_mmm_mar')` +
-					`.outE('usedBy')` +
-					`.where(otherV().hasLabel('_code_list').has('_code_list', 'listID', 'mmm'))`
+				expectedQry := `g.V().hasLabel('_code_list').has('_code_list', 'listID', 'yyyy-qq').inE('usedBy').has('label', '2016 Q1')`
 				So(poolMock.GetECalls(), ShouldHaveLength, 1)
 				So(poolMock.GetECalls()[0].Q, ShouldEqual, expectedQry)
 			})
@@ -659,10 +655,10 @@ func TestGetCodeOrder(t *testing.T) {
 		db := mockDB(poolMock)
 
 		Convey("When GetCodeOrder() is called", func() {
-			_, err := db.GetCodeOrder(context.Background(), testCodeListID, testCode)
+			_, err := db.GetCodeOrder(context.Background(), testCodeListID, testCodeLabel)
 
 			Convey("Then the wrapped error should be returned", func() {
-				expectedErr := "Gremlin query failed: \"g.V().hasId('_code_mmm_mar').outE('usedBy').where(otherV().hasLabel('_code_list').has('_code_list', 'listID', 'mmm'))\": number of attempts exceeded: getE failed"
+				expectedErr := "Gremlin query failed: \"g.V().hasLabel('_code_list').has('_code_list', 'listID', 'yyyy-qq').inE('usedBy').has('label', '2016 Q1')\": number of attempts exceeded: getE failed"
 				So(err.Error(), ShouldResemble, expectedErr)
 			})
 		})
@@ -677,7 +673,7 @@ func TestGetCodeOrder(t *testing.T) {
 		db := mockDB(poolMock)
 
 		Convey("When GetCodeOrder() is called", func() {
-			_, err := db.GetCodeOrder(context.Background(), testCodeListID, testCode)
+			_, err := db.GetCodeOrder(context.Background(), testCodeListID, testCodeLabel)
 
 			Convey("Then a notFound error should be returned", func() {
 				So(err, ShouldResemble, driver.ErrNotFound)
@@ -709,7 +705,7 @@ func TestGetCodeOrder(t *testing.T) {
 		db := mockDB(poolMock)
 
 		Convey("When GetCodeOrder() is called", func() {
-			_, err := db.GetCodeOrder(context.Background(), testCodeListID, testCode)
+			_, err := db.GetCodeOrder(context.Background(), testCodeListID, testCodeLabel)
 
 			Convey("Then a multipleFound error should be returned", func() {
 				So(err, ShouldResemble, driver.ErrMultipleFound)
@@ -742,7 +738,7 @@ func TestGetCodeOrder(t *testing.T) {
 		db := mockDB(poolMock)
 
 		Convey("When GetCodeOrder() is called", func() {
-			_, err := db.GetCodeOrder(context.Background(), testCodeListID, testCode)
+			_, err := db.GetCodeOrder(context.Background(), testCodeListID, testCodeLabel)
 
 			Convey("Then the expected unmarshal order should be returned", func() {
 				So(err.Error(), ShouldResemble, "invalid character '\\x01' looking for beginning of value")

--- a/neptune/query/query.go
+++ b/neptune/query/query.go
@@ -28,10 +28,8 @@ const (
 	CodeExists = `g.V().hasLabel('_code_list')` +
 		`.has('listID', '%s').has('edition', '%s')` +
 		`.in('usedBy').has('value', "%s").count()`
-	GetUsedByEdge = `g.V().hasId('_code_%s_%s')` +
-		`.outE('usedBy')` +
-		`.where(otherV().hasLabel('_code_list').has('_code_list', 'listID', '%s'))`
-
+	GetUsedByEdge = `g.V().hasLabel('_code_list').has('_code_list', 'listID', '%s')` +
+		`.inE('usedBy').has('label', '%s')`
 	/*
 		This query harvests data from both edges and nodes, so we collapse
 		the response to contain only strings - to make it parse-able with


### PR DESCRIPTION
### What

- Fixed GetUsedByEdge query to use code label instead of code
- Fixed unit tests accordingly
- Upgraded to go version 1.16
The reason for this change is that the dimension importer uses the code label instead of the code

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

### Who can review

Anyone