### PR TITLE
Add `HierarchyExists` function

### DIFF
--- a/graph/driver/driver.go
+++ b/graph/driver/driver.go
@@ -31,6 +31,7 @@ type CodeList interface {
 // Hierarchy defines functions to create and retrieve generic and instance hierarchy nodes
 type Hierarchy interface {
 	// read
+	HierarchyExists(ctx context.Context, instanceID, dimension string) (hierarchyExists bool, err error)
 	GetHierarchyCodelist(ctx context.Context, instanceID, dimension string) (string, error)
 	GetHierarchyRoot(ctx context.Context, instanceID, dimension string) (*models.HierarchyResponse, error)
 	GetHierarchyElement(ctx context.Context, instanceID, dimension, code string) (*models.HierarchyResponse, error)

--- a/mock/hierarchy.go
+++ b/mock/hierarchy.go
@@ -6,6 +6,10 @@ import (
 	"github.com/ONSdigital/dp-graph/v2/models"
 )
 
+func (m *Mock) HierarchyExists(ctx context.Context, instanceID, dimension string) (hierarchyExists bool, err error) {
+	return true, m.checkForErrors()
+}
+
 func (m *Mock) CreateInstanceHierarchyConstraints(ctx context.Context, attempt int, instanceID, dimensionName string) error {
 	return m.checkForErrors()
 }

--- a/neo4j/hierarchy_reader.go
+++ b/neo4j/hierarchy_reader.go
@@ -80,6 +80,7 @@ func (n *Neo4j) HierarchyExists(ctx context.Context, instanceID, dimension strin
 	}
 
 	if len(vertices) > 1 {
+		hierarchyExists = true
 		err = driver.ErrMultipleFound
 		log.Event(ctx, "expected a single hierarchy node but multiple were returned", log.ERROR, logData, log.Error(err))
 		return hierarchyExists, err

--- a/neo4j/hierarchy_reader.go
+++ b/neo4j/hierarchy_reader.go
@@ -66,26 +66,26 @@ func (n *Neo4j) HierarchyExists(ctx context.Context, instanceID, dimension strin
 
 	if vertices, err = n.queryElements(ctx, instanceID, dimension, neoStmt, neoArgMap{}); err != nil {
 		if err == driver.ErrNotFound {
-			return false, nil
+			hierarchyExists = false
+			return hierarchyExists, nil
 		}
 
 		log.Event(ctx, "queryElements failed when attempting to get a hierarchy node", log.ERROR, logData, log.Error(err))
 		return
 	}
 
+	if len(vertices) == 1 {
+		hierarchyExists = true
+		return hierarchyExists, nil
+	}
+
 	if len(vertices) > 1 {
 		err = driver.ErrMultipleFound
 		log.Event(ctx, "expected a single hierarchy node but multiple were returned", log.ERROR, logData, log.Error(err))
-		return
+		return hierarchyExists, err
 	}
 
-	hierarchyExists = false
-
-	if len(vertices) == 1 {
-		hierarchyExists = true
-	}
-
-	return
+	return hierarchyExists, nil
 }
 
 // queryResponse performs DB query (neoStmt, neoArgs) returning Response (should be singular)

--- a/neo4j/hierarchy_test.go
+++ b/neo4j/hierarchy_test.go
@@ -587,8 +587,8 @@ func TestStore_HierarchyExists(t *testing.T) {
 				So(neoDriverMock.ReadWithParamsCalls()[0].Query, ShouldEqual, expectedQuery)
 			})
 
-			Convey("Then the return value should be false", func() {
-				So(hierarchyExists, ShouldBeFalse)
+			Convey("Then the return value should be true", func() {
+				So(hierarchyExists, ShouldBeTrue)
 			})
 
 			Convey("Then the expected error is returned", func() {

--- a/neo4j/hierarchy_test.go
+++ b/neo4j/hierarchy_test.go
@@ -30,7 +30,7 @@ var (
 
 func Test_CreateInstanceHierarchyConstraints(t *testing.T) {
 
-	Convey("Given a mock bolt connection", t, func() {
+	Convey("Given a bolt connection", t, func() {
 		driver := &internal.Neo4jDriverMock{
 			ExecFunc: func(q string, params map[string]interface{}) (bolt.Result, error) {
 				return &internal.ResultMock{}, nil
@@ -62,7 +62,7 @@ func Test_CreateInstanceHierarchyConstraints(t *testing.T) {
 
 func Test_CreateInstanceHierarchyConstraints_NeoErrExec(t *testing.T) {
 
-	Convey("Given a mock bolt connection that returns an error", t, func() {
+	Convey("Given a bolt connection that returns an error", t, func() {
 		driver := &internal.Neo4jDriverMock{
 			ExecFunc: func(q string, params map[string]interface{}) (bolt.Result, error) {
 				return nil, errExec
@@ -86,7 +86,7 @@ func Test_CreateInstanceHierarchyConstraints_NeoErrExec(t *testing.T) {
 }
 
 func TestStore_CreateInstanceHierarchyConstraints_NeoExecRetry(t *testing.T) {
-	Convey("Given a mock bolt connection that returns a transient error", t, func() {
+	Convey("Given a bolt connection that returns a transient error", t, func() {
 		transientNeoErr := neoErrors.Wrap(messages.FailureMessage{Metadata: map[string]interface{}{"code": "Neo.TransientError.Transaction.ConstraintsChanged"}}, "constraint error msg")
 
 		driver := &internal.Neo4jDriverMock{
@@ -121,7 +121,7 @@ func TestStore_CloneNodes(t *testing.T) {
 		dimensionName,
 	)
 
-	Convey("Given a mock bolt connection", t, func() {
+	Convey("Given a bolt connection", t, func() {
 		driver := &internal.Neo4jDriverMock{
 			ExecFunc: func(q string, params map[string]interface{}) (bolt.Result, error) {
 				return &internal.ResultMock{}, nil
@@ -147,7 +147,7 @@ func TestStore_CloneNodes(t *testing.T) {
 
 func TestStore_CloneNodes_NeoerrExec(t *testing.T) {
 
-	Convey("Given a mock bolt connection that returns an error", t, func() {
+	Convey("Given a bolt connection that returns an error", t, func() {
 		driver := &internal.Neo4jDriverMock{
 			ExecFunc: func(q string, params map[string]interface{}) (bolt.Result, error) {
 				return nil, errExec
@@ -186,7 +186,7 @@ func TestStore_CloneRelationships(t *testing.T) {
 		dimensionName,
 	)
 
-	Convey("Given a mock bolt connection", t, func() {
+	Convey("Given a bolt connection", t, func() {
 		driver := &internal.Neo4jDriverMock{
 			ExecFunc: func(q string, params map[string]interface{}) (bolt.Result, error) {
 				return &internal.ResultMock{}, nil
@@ -212,7 +212,7 @@ func TestStore_CloneRelationships(t *testing.T) {
 
 func TestStore_CloneRelationships_NeoErrExec(t *testing.T) {
 
-	Convey("Given a mock bolt connection that returns an error", t, func() {
+	Convey("Given a bolt connection that returns an error", t, func() {
 		driver := &internal.Neo4jDriverMock{
 			ExecFunc: func(q string, params map[string]interface{}) (bolt.Result, error) {
 				return nil, errExec
@@ -247,7 +247,7 @@ func TestStore_SetNumberOfChildren(t *testing.T) {
 		dimensionName,
 	)
 
-	Convey("Given a mock bolt connection", t, func() {
+	Convey("Given a bolt connection", t, func() {
 		driver := &internal.Neo4jDriverMock{
 			ExecFunc: func(q string, params map[string]interface{}) (bolt.Result, error) {
 				return &internal.ResultMock{}, nil
@@ -273,7 +273,7 @@ func TestStore_SetNumberOfChildren(t *testing.T) {
 
 func TestStore_SetNumberOfChildren_NeoErrExec(t *testing.T) {
 
-	Convey("Given a mock bolt connection that returns an error", t, func() {
+	Convey("Given a bolt connection that returns an error", t, func() {
 		driver := &internal.Neo4jDriverMock{
 			ExecFunc: func(q string, params map[string]interface{}) (bolt.Result, error) {
 				return nil, errExec
@@ -306,7 +306,7 @@ func TestStore_SetHasData(t *testing.T) {
 		dimensionName,
 	)
 
-	Convey("Given a mock bolt connection", t, func() {
+	Convey("Given a bolt connection", t, func() {
 		driver := &internal.Neo4jDriverMock{
 			ExecFunc: func(q string, params map[string]interface{}) (bolt.Result, error) {
 				return &internal.ResultMock{}, nil
@@ -332,7 +332,7 @@ func TestStore_SetHasData(t *testing.T) {
 
 func TestStore_SetHasData_NeoErrExec(t *testing.T) {
 
-	Convey("Given a mock bolt connection that returns an error", t, func() {
+	Convey("Given a bolt connection that returns an error", t, func() {
 		driver := &internal.Neo4jDriverMock{
 			ExecFunc: func(q string, params map[string]interface{}) (bolt.Result, error) {
 				return nil, errExec
@@ -365,7 +365,7 @@ func TestStore_MarkNodesToRemain(t *testing.T) {
 		dimensionName,
 	)
 
-	Convey("Given a mock bolt connection", t, func() {
+	Convey("Given a bolt connection", t, func() {
 		driver := &internal.Neo4jDriverMock{
 			ExecFunc: func(q string, params map[string]interface{}) (bolt.Result, error) {
 				return &internal.ResultMock{}, nil
@@ -391,7 +391,7 @@ func TestStore_MarkNodesToRemain(t *testing.T) {
 
 func TestStore_MarkNodesToRemain_NeoErrExec(t *testing.T) {
 
-	Convey("Given a mock bolt connection that returns an error", t, func() {
+	Convey("Given a bolt connection that returns an error", t, func() {
 		driver := &internal.Neo4jDriverMock{
 			ExecFunc: func(q string, params map[string]interface{}) (bolt.Result, error) {
 				return nil, errExec
@@ -421,7 +421,7 @@ func TestStore_RemoveNodesNotMarkedToRemain(t *testing.T) {
 		dimensionName,
 	)
 
-	Convey("Given a mock bolt connection", t, func() {
+	Convey("Given a bolt connection", t, func() {
 		driver := &internal.Neo4jDriverMock{
 			ExecFunc: func(q string, params map[string]interface{}) (bolt.Result, error) {
 				return &internal.ResultMock{}, nil
@@ -447,7 +447,7 @@ func TestStore_RemoveNodesNotMarkedToRemain(t *testing.T) {
 
 func TestStore_RemoveNodesNotMarkedToRemain_NeoErrExec(t *testing.T) {
 
-	Convey("Given a mock bolt connection that returns an error", t, func() {
+	Convey("Given a bolt connection that returns an error", t, func() {
 		driver := &internal.Neo4jDriverMock{
 			ExecFunc: func(q string, params map[string]interface{}) (bolt.Result, error) {
 				return nil, errExec
@@ -477,7 +477,7 @@ func TestStore_RemoveRemainMarker(t *testing.T) {
 		dimensionName,
 	)
 
-	Convey("Given a mock bolt connection", t, func() {
+	Convey("Given a bolt connection", t, func() {
 		driver := &internal.Neo4jDriverMock{
 			ExecFunc: func(q string, params map[string]interface{}) (bolt.Result, error) {
 				return &internal.ResultMock{}, nil
@@ -503,7 +503,7 @@ func TestStore_RemoveRemainMarker(t *testing.T) {
 
 func TestStore_RemoveRemainMarker_NeoErrExec(t *testing.T) {
 
-	Convey("Given a mock bolt connection that returns an error", t, func() {
+	Convey("Given a bolt connection that returns an error", t, func() {
 		driver := &internal.Neo4jDriverMock{
 			ExecFunc: func(q string, params map[string]interface{}) (bolt.Result, error) {
 				return nil, errExec
@@ -537,7 +537,7 @@ func TestStore_HierarchyExists(t *testing.T) {
 		Index: 0,
 	}
 
-	Convey("Given a mock bolt connection that returns a node", t, func() {
+	Convey("Given a bolt connection that returns a node", t, func() {
 		neoDriverMock := &internal.Neo4jDriverMock{
 			ReadWithParamsFunc: func(query string, params map[string]interface{}, mapp mapper.ResultMapper, single bool) error {
 				mapp(mockNeoResponse)
@@ -566,7 +566,7 @@ func TestStore_HierarchyExists(t *testing.T) {
 		})
 	})
 
-	Convey("Given a mock bolt connection that returns multiple nodes", t, func() {
+	Convey("Given a bolt connection that returns multiple nodes", t, func() {
 		neoDriverMock := &internal.Neo4jDriverMock{
 			ReadWithParamsFunc: func(query string, params map[string]interface{}, mapp mapper.ResultMapper, single bool) error {
 				mapp(mockNeoResponse)
@@ -597,7 +597,7 @@ func TestStore_HierarchyExists(t *testing.T) {
 		})
 	})
 
-	Convey("Given a mock bolt connection that returns an empty result set", t, func() {
+	Convey("Given a bolt connection that returns an empty result set", t, func() {
 		neoDriverMock := &internal.Neo4jDriverMock{
 			ReadWithParamsFunc: func(query string, params map[string]interface{}, mapp mapper.ResultMapper, single bool) error {
 				return nil
@@ -625,7 +625,7 @@ func TestStore_HierarchyExists(t *testing.T) {
 		})
 	})
 
-	Convey("Given a mock bolt connection that returns a not found error", t, func() {
+	Convey("Given a bolt connection that returns a not found error", t, func() {
 
 		expectedError := driver.ErrNotFound
 
@@ -656,7 +656,7 @@ func TestStore_HierarchyExists(t *testing.T) {
 		})
 	})
 
-	Convey("Given a mock bolt connection that returns an error", t, func() {
+	Convey("Given a bolt connection that returns an error", t, func() {
 
 		expectedError := errors.New("test error")
 

--- a/neptune/hierarchy.go
+++ b/neptune/hierarchy.go
@@ -526,6 +526,36 @@ func (n *NeptuneDB) GetHierarchyRoot(ctx context.Context, instanceID, dimension 
 	return
 }
 
+func (n *NeptuneDB) HierarchyExists(ctx context.Context, instanceID, dimension string) (hierarchyExists bool, err error) {
+	gremStmt := fmt.Sprintf(query.HierarchyExists, instanceID, dimension)
+	logData := log.Data{
+		"fn":             "HierarchyExists",
+		"gremlin":        gremStmt,
+		"instance_id":    instanceID,
+		"dimension_name": dimension,
+	}
+
+	var vertices []graphson.Vertex
+	if vertices, err = n.getVertices(gremStmt); err != nil {
+		log.Event(ctx, "getVertices failed when attempting to get a hierarchy node", log.ERROR, logData, log.Error(err))
+		return
+	}
+
+	if len(vertices) > 1 {
+		err = driver.ErrMultipleFound
+		log.Event(ctx, "expected a single hierarchy node but multiple were returned", log.ERROR, logData, log.Error(err))
+		return
+	}
+
+	hierarchyExists = false
+
+	if len(vertices) == 1 {
+		hierarchyExists = true
+	}
+
+	return
+}
+
 func (n *NeptuneDB) GetHierarchyElement(ctx context.Context, instanceID, dimension, code string) (node *models.HierarchyResponse, err error) {
 	gremStmt := fmt.Sprintf(query.GetHierarchyElement, instanceID, dimension, code)
 	logData := log.Data{

--- a/neptune/hierarchy.go
+++ b/neptune/hierarchy.go
@@ -541,19 +541,18 @@ func (n *NeptuneDB) HierarchyExists(ctx context.Context, instanceID, dimension s
 		return
 	}
 
+	if len(vertices) == 1 {
+		hierarchyExists = true
+		return hierarchyExists, nil
+	}
+
 	if len(vertices) > 1 {
 		err = driver.ErrMultipleFound
 		log.Event(ctx, "expected a single hierarchy node but multiple were returned", log.ERROR, logData, log.Error(err))
-		return
+		return hierarchyExists, err
 	}
 
-	hierarchyExists = false
-
-	if len(vertices) == 1 {
-		hierarchyExists = true
-	}
-
-	return
+	return hierarchyExists, nil
 }
 
 func (n *NeptuneDB) GetHierarchyElement(ctx context.Context, instanceID, dimension, code string) (node *models.HierarchyResponse, err error) {

--- a/neptune/hierarchy.go
+++ b/neptune/hierarchy.go
@@ -547,6 +547,7 @@ func (n *NeptuneDB) HierarchyExists(ctx context.Context, instanceID, dimension s
 	}
 
 	if len(vertices) > 1 {
+		hierarchyExists = true
 		err = driver.ErrMultipleFound
 		log.Event(ctx, "expected a single hierarchy node but multiple were returned", log.ERROR, logData, log.Error(err))
 		return hierarchyExists, err

--- a/neptune/hierarchy_test.go
+++ b/neptune/hierarchy_test.go
@@ -42,7 +42,7 @@ var (
 
 func TestNeptuneDB_GetCodesWithData(t *testing.T) {
 
-	Convey("Given a mocked neptune DB that returns a code list", t, func() {
+	Convey("Given a neptune DB that returns a code list", t, func() {
 		poolMock := &internal.NeptunePoolMock{
 			GetStringListFunc: internal.ReturnCodesList,
 		}
@@ -71,7 +71,7 @@ func TestNeptuneDB_HierarchyExists(t *testing.T) {
 
 	vertex := internal.MakeHierarchyVertex("vertex-label", "code", "label", 1, true)
 
-	Convey("Given a mocked neptune DB that returns a single hierarchy node", t, func() {
+	Convey("Given a neptune DB that returns a single hierarchy node", t, func() {
 
 		poolMock := &internal.NeptunePoolMock{GetFunc: func(query string, bindings map[string]string, rebindings map[string]string) (vertices []graphson.Vertex, err error) {
 			return []graphson.Vertex{vertex}, nil
@@ -95,7 +95,7 @@ func TestNeptuneDB_HierarchyExists(t *testing.T) {
 		})
 	})
 
-	Convey("Given a mocked neptune DB that returns multiple hierarchy nodes", t, func() {
+	Convey("Given a neptune DB that returns multiple hierarchy nodes", t, func() {
 
 		poolMock := &internal.NeptunePoolMock{GetFunc: func(query string, bindings map[string]string, rebindings map[string]string) (vertices []graphson.Vertex, err error) {
 			return []graphson.Vertex{vertex, vertex}, nil
@@ -103,7 +103,7 @@ func TestNeptuneDB_HierarchyExists(t *testing.T) {
 		db := mockDB(poolMock)
 
 		Convey("When HierarchyExists is called", func() {
-			_, err := db.HierarchyExists(ctx, testInstanceID, testDimensionName)
+			hierarchyExists, err := db.HierarchyExists(ctx, testInstanceID, testDimensionName)
 
 			Convey("Then the expected query is sent to Neptune", func() {
 
@@ -112,13 +112,17 @@ func TestNeptuneDB_HierarchyExists(t *testing.T) {
 				So(poolMock.GetCalls()[0].Query, ShouldEqual, expectedQuery)
 			})
 
+			Convey("Then the return value should be false", func() {
+				So(hierarchyExists, ShouldBeFalse)
+			})
+
 			Convey("Then the expected error is returned", func() {
 				So(err, ShouldEqual, driver.ErrMultipleFound)
 			})
 		})
 	})
 
-	Convey("Given a mocked neptune DB that returns an empty array of vertices", t, func() {
+	Convey("Given a neptune DB that returns an empty array of vertices", t, func() {
 
 		poolMock := &internal.NeptunePoolMock{GetFunc: func(query string, bindings map[string]string, rebindings map[string]string) (vertices []graphson.Vertex, err error) {
 			return []graphson.Vertex{}, nil
@@ -141,7 +145,7 @@ func TestNeptuneDB_HierarchyExists(t *testing.T) {
 		})
 	})
 
-	Convey("Given a mocked neptune DB that returns an error", t, func() {
+	Convey("Given a neptune DB that returns an error", t, func() {
 
 		poolMock := &internal.NeptunePoolMock{
 			GetFunc: internal.ReturnMalformedNilInterfaceRequestErr,
@@ -149,12 +153,16 @@ func TestNeptuneDB_HierarchyExists(t *testing.T) {
 		db := mockDB(poolMock)
 
 		Convey("When HierarchyExists is called", func() {
-			_, err := db.HierarchyExists(ctx, testInstanceID, testDimensionName)
+			hierarchyExists, err := db.HierarchyExists(ctx, testInstanceID, testDimensionName)
 
 			Convey("Then the expected query is sent to Neptune", func() {
 				expectedQuery := fmt.Sprintf(query.HierarchyExists, testInstanceID, testDimensionName)
 				So(len(poolMock.GetCalls()), ShouldEqual, 1)
 				So(poolMock.GetCalls()[0].Query, ShouldEqual, expectedQuery)
+			})
+
+			Convey("Then the return value should be false", func() {
+				So(hierarchyExists, ShouldBeFalse)
 			})
 
 			Convey("Then the expected error is returned", func() {
@@ -166,7 +174,7 @@ func TestNeptuneDB_HierarchyExists(t *testing.T) {
 
 func TestNeptuneDB_GetGenericHierarchyNodeIDs(t *testing.T) {
 
-	Convey("Given a mocked neptune DB that returns a list of generic hierarchy node IDs (leaves)", t, func() {
+	Convey("Given a neptune DB that returns a list of generic hierarchy node IDs (leaves)", t, func() {
 		poolMock := &internal.NeptunePoolMock{
 			GetStringListFunc: internal.ReturnGenericHierarchyLeavesIDs,
 		}
@@ -207,7 +215,7 @@ func TestNeptuneDB_GetGenericHierarchyNodeIDs(t *testing.T) {
 
 func TestNeptuneDB_GetGenericHierarchyAncestriesIDs(t *testing.T) {
 
-	Convey("Given a mocked neptune DB that returns a list of generic ancestry hierarchy node IDs, with duplicates", t, func() {
+	Convey("Given a neptune DB that returns a list of generic ancestry hierarchy node IDs, with duplicates", t, func() {
 		poolMock := &internal.NeptunePoolMock{
 			GetStringListFunc: internal.ReturnGenericHierarchyAncestryIDs,
 		}
@@ -249,7 +257,7 @@ func TestNeptuneDB_GetGenericHierarchyAncestriesIDs(t *testing.T) {
 
 func TestNeptuneDB_CloneNodesFromID(t *testing.T) {
 
-	Convey("Given a mocked neptune DB", t, func() {
+	Convey("Given a neptune DB", t, func() {
 		poolMock := &internal.NeptunePoolMock{
 			ExecuteFunc: func(query string, bindings map[string]string, rebindings map[string]string) (responses []gremgo.Response, err error) {
 				return []gremgo.Response{}, nil
@@ -295,7 +303,7 @@ func TestNeptuneDB_CloneNodesFromID(t *testing.T) {
 
 func TestNeptuneDB_CountNodes(t *testing.T) {
 
-	Convey("Given a mocked neptune DB", t, func() {
+	Convey("Given a neptune DB", t, func() {
 		var expectedCount int64 = 123
 		poolMock := &internal.NeptunePoolMock{
 			GetCountFunc: func(q string, bindings map[string]string, rebindings map[string]string) (int64, error) {
@@ -323,7 +331,7 @@ func TestNeptuneDB_CountNodes(t *testing.T) {
 
 func TestNeptuneDB_CloneRelationshipsFromIDs(t *testing.T) {
 
-	Convey("Given a mocked neptune DB", t, func() {
+	Convey("Given a neptune DB", t, func() {
 		poolMock := &internal.NeptunePoolMock{
 			GetEFunc: func(q string, bindings, rebindings map[string]string) (resp interface{}, err error) {
 				return []graphson.Edge{}, nil
@@ -372,7 +380,7 @@ func TestNeptuneDB_CloneRelationshipsFromIDs(t *testing.T) {
 
 func TestNeptuneDB_RemoveCloneEdges(t *testing.T) {
 
-	Convey("Given a mocked neptune DB", t, func() {
+	Convey("Given a neptune DB", t, func() {
 		poolMock := &internal.NeptunePoolMock{
 			ExecuteFunc: func(query string, bindings map[string]string, rebindings map[string]string) (responses []gremgo.Response, err error) {
 				return []gremgo.Response{}, nil
@@ -398,7 +406,7 @@ func TestNeptuneDB_RemoveCloneEdges(t *testing.T) {
 
 func TestNeptuneDB_RemoveCloneEdgesFromSourceIDs(t *testing.T) {
 
-	Convey("Given a mocked neptune DB", t, func() {
+	Convey("Given a neptune DB", t, func() {
 		poolMock := &internal.NeptunePoolMock{
 			ExecuteFunc: func(query string, bindings map[string]string, rebindings map[string]string) (responses []gremgo.Response, err error) {
 				return []gremgo.Response{}, nil
@@ -441,7 +449,7 @@ func TestNeptuneDB_RemoveCloneEdgesFromSourceIDs(t *testing.T) {
 
 func TestNeptuneDB_GetHierarchyNodeIDs(t *testing.T) {
 
-	Convey("Given a mocked neptune DB", t, func() {
+	Convey("Given a neptune DB", t, func() {
 		poolMock := &internal.NeptunePoolMock{
 			GetStringListFunc: internal.ReturnHierarchyNodeIDs,
 		}
@@ -466,7 +474,7 @@ func TestNeptuneDB_GetHierarchyNodeIDs(t *testing.T) {
 
 func TestNeptuneDB_SetNumberOfChildren(t *testing.T) {
 
-	Convey("Given a mocked neptune DB", t, func() {
+	Convey("Given a neptune DB", t, func() {
 		poolMock := &internal.NeptunePoolMock{
 			ExecuteFunc: func(query string, bindings map[string]string, rebindings map[string]string) (responses []gremgo.Response, err error) {
 				return []gremgo.Response{}, nil
@@ -492,7 +500,7 @@ func TestNeptuneDB_SetNumberOfChildren(t *testing.T) {
 
 func TestNeptuneDB_SetNumberOfChildrenFromIDs(t *testing.T) {
 
-	Convey("Given a mocked neptune DB", t, func() {
+	Convey("Given a neptune DB", t, func() {
 		poolMock := &internal.NeptunePoolMock{
 			ExecuteFunc: func(query string, bindings map[string]string, rebindings map[string]string) (responses []gremgo.Response, err error) {
 				return []gremgo.Response{}, nil
@@ -535,7 +543,7 @@ func TestNeptuneDB_SetNumberOfChildrenFromIDs(t *testing.T) {
 
 func TestNeptuneDB_SetHasData(t *testing.T) {
 
-	Convey("Given a mocked neptune DB that returns a code list", t, func() {
+	Convey("Given a neptune DB that returns a code list", t, func() {
 
 		ctx := context.Background()
 		attempt := 1

--- a/neptune/hierarchy_test.go
+++ b/neptune/hierarchy_test.go
@@ -112,8 +112,8 @@ func TestNeptuneDB_HierarchyExists(t *testing.T) {
 				So(poolMock.GetCalls()[0].Query, ShouldEqual, expectedQuery)
 			})
 
-			Convey("Then the return value should be false", func() {
-				So(hierarchyExists, ShouldBeFalse)
+			Convey("Then the return value should be true", func() {
+				So(hierarchyExists, ShouldBeTrue)
 			})
 
 			Convey("Then the expected error is returned", func() {

--- a/neptune/internal/mockpoolutils.go
+++ b/neptune/internal/mockpoolutils.go
@@ -13,6 +13,10 @@ This module provides a handful of mock convenience functions that can be
 used to inject behaviour into NeptunePoolMock.
 */
 
+// a mock error that is judged to be not transient by neptune.isTransientError
+// which prevents retry attempts in tests
+var NonTransientErr = errors.New(" MALFORMED REQUEST ")
+
 // ReturnOne is a mock implementation for NeptunePool.GetCount()
 // that always returns a count of 1.
 var ReturnOne = func(q string, bindings, rebindings map[string]string) (i int64, err error) {
@@ -41,21 +45,21 @@ var ReturnZero = func(q string, bindings, rebindings map[string]string) (i int64
 // that always returns an error that is judged to be not transient by
 // neptune.isTransientError
 var ReturnMalformedIntRequestErr = func(q string, bindings, rebindings map[string]string) (i int64, err error) {
-	return -1, errors.New(" MALFORMED REQUEST ")
+	return -1, NonTransientErr
 }
 
 // ReturnMalformedNilInterfaceRequestErr is a mock implementation for
 // NeptunePool functions that return  ([]graphson.Vertex, error) which always returns an
 // error that is judged to be not transient by neptune.isTransientError
 var ReturnMalformedNilInterfaceRequestErr = func(q string, bindings, rebindings map[string]string) ([]graphson.Vertex, error) {
-	return nil, errors.New(" MALFORMED REQUEST ")
+	return nil, NonTransientErr
 }
 
 // ReturnMalformedStringListRequestErr is a mock implementation for
 // NeptunePool functions that return  ([]string, error) which always returns an
 // error that is judged to be not transient by neptune.isTransientError
 var ReturnMalformedStringListRequestErr = func(q string, bindings, rebindings map[string]string) ([]string, error) {
-	return nil, errors.New(" MALFORMED REQUEST ")
+	return nil, NonTransientErr
 }
 
 // ReturnThreeCodeLists is mock implementation for NeptunePool.Get() that always


### PR DESCRIPTION
### What
Add `HierarchyExists` function
- add `HierarchyExists` function to the hierarchy interface
- add Neptune and Neo4j implementations
- create common error type for testing Neptune error responses without triggering retries

### How to review
Review and check tests. Integration testing will be done in the hierarchy builder change.

### Who can review
Anyone