### PR TITLE
Clone code order during hierarchy build

### DIFF
--- a/graph/driver/driver.go
+++ b/graph/driver/driver.go
@@ -47,6 +47,7 @@ type Hierarchy interface {
 	CloneRelationships(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string) error
 	CloneRelationshipsFromIDs(ctx context.Context, attempt int, instanceID, dimensionName string, ids map[string]string) error
 	CreateHasCodeEdges(ctx context.Context, attempt int, codeListID string, codesById map[string]string) (err error)
+	CloneOrderFromIDs(ctx context.Context, codeListID string, ids map[string]string) (err error)
 	SetNumberOfChildren(ctx context.Context, attempt int, instanceID, dimensionName string) (err error)
 	SetNumberOfChildrenFromIDs(ctx context.Context, attempt int, ids map[string]string) (err error)
 	RemoveCloneEdges(ctx context.Context, attempt int, instanceID, dimensionName string) (err error)

--- a/graph/driver/driver.go
+++ b/graph/driver/driver.go
@@ -39,17 +39,18 @@ type Hierarchy interface {
 	GetGenericHierarchyNodeIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs map[string]string, err error)
 	GetGenericHierarchyAncestriesIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs map[string]string, err error)
 	CountNodes(ctx context.Context, instanceID, dimensionName string) (count int64, err error)
-	GetHierarchyNodeIDs(ctx context.Context, attempt int, instanceID, dimensionName string) (ids map[string]struct{}, err error)
+	GetHierarchyNodeIDs(ctx context.Context, attempt int, instanceID, dimensionName string) (ids map[string]string, err error)
 	// write
 	CreateInstanceHierarchyConstraints(ctx context.Context, attempt int, instanceID, dimensionName string) error
 	CloneNodes(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string) error
-	CloneNodesFromIDs(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string, ids map[string]struct{}, hasData bool) (err error)
+	CloneNodesFromIDs(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string, ids map[string]string, hasData bool) (err error)
 	CloneRelationships(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string) error
-	CloneRelationshipsFromIDs(ctx context.Context, attempt int, instanceID, dimensionName string, ids map[string]struct{}) error
+	CloneRelationshipsFromIDs(ctx context.Context, attempt int, instanceID, dimensionName string, ids map[string]string) error
+	CreateHasCodeEdges(ctx context.Context, attempt int, codeListID string, codesById map[string]string) (err error)
 	SetNumberOfChildren(ctx context.Context, attempt int, instanceID, dimensionName string) (err error)
-	SetNumberOfChildrenFromIDs(ctx context.Context, attempt int, ids map[string]struct{}) (err error)
+	SetNumberOfChildrenFromIDs(ctx context.Context, attempt int, ids map[string]string) (err error)
 	RemoveCloneEdges(ctx context.Context, attempt int, instanceID, dimensionName string) (err error)
-	RemoveCloneEdgesFromSourceIDs(ctx context.Context, attempt int, ids map[string]struct{}) (err error)
+	RemoveCloneEdgesFromSourceIDs(ctx context.Context, attempt int, ids map[string]string) (err error)
 	SetHasData(ctx context.Context, attempt int, instanceID, dimensionName string) error
 	MarkNodesToRemain(ctx context.Context, attempt int, instanceID, dimensionName string) error
 	RemoveNodesNotMarkedToRemain(ctx context.Context, attempt int, instanceID, dimensionName string) error

--- a/graph/driver/driver.go
+++ b/graph/driver/driver.go
@@ -36,8 +36,8 @@ type Hierarchy interface {
 	GetHierarchyRoot(ctx context.Context, instanceID, dimension string) (*models.HierarchyResponse, error)
 	GetHierarchyElement(ctx context.Context, instanceID, dimension, code string) (*models.HierarchyResponse, error)
 	GetCodesWithData(ctx context.Context, attempt int, instanceID, dimensionName string) (codes []string, err error)
-	GetGenericHierarchyNodeIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs map[string]struct{}, err error)
-	GetGenericHierarchyAncestriesIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs map[string]struct{}, err error)
+	GetGenericHierarchyNodeIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs map[string]string, err error)
+	GetGenericHierarchyAncestriesIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs map[string]string, err error)
 	CountNodes(ctx context.Context, instanceID, dimensionName string) (count int64, err error)
 	GetHierarchyNodeIDs(ctx context.Context, attempt int, instanceID, dimensionName string) (ids map[string]struct{}, err error)
 	// write

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -74,6 +74,7 @@ func New(ctx context.Context, choice Subsets) (*DB, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	log.Event(ctx, "loaded graph database config", log.INFO, log.Data{"config": cfg})
 
 	var ok bool

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"context"
 	"errors"
+
 	"github.com/ONSdigital/log.go/log"
 
 	"github.com/ONSdigital/dp-graph/v2/config"
@@ -73,7 +74,6 @@ func New(ctx context.Context, choice Subsets) (*DB, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	log.Event(ctx, "loaded graph database config", log.INFO, log.Data{"config": cfg})
 
 	var ok bool

--- a/mock/hierarchy.go
+++ b/mock/hierarchy.go
@@ -26,11 +26,15 @@ func (m *Mock) GetGenericHierarchyAncestriesIDs(ctx context.Context, attempt int
 	return map[string]string{}, m.checkForErrors()
 }
 
+func (m *Mock) CreateHasCodeEdges(ctx context.Context, attempt int, codeListID string, codesById map[string]string) (err error) {
+	return m.checkForErrors()
+}
+
 func (m *Mock) CloneNodes(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string) error {
 	return m.checkForErrors()
 }
 
-func (m *Mock) CloneNodesFromIDs(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string, ids map[string]struct{}, hasData bool) (err error) {
+func (m *Mock) CloneNodesFromIDs(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string, ids map[string]string, hasData bool) (err error) {
 	return m.checkForErrors()
 }
 
@@ -38,15 +42,15 @@ func (m *Mock) CountNodes(ctx context.Context, instanceID, dimensionName string)
 	return 0, m.checkForErrors()
 }
 
-func (m *Mock) GetHierarchyNodeIDs(ctx context.Context, attempt int, instanceID, dimensionName string) (ids map[string]struct{}, err error) {
-	return map[string]struct{}{}, m.checkForErrors()
+func (m *Mock) GetHierarchyNodeIDs(ctx context.Context, attempt int, instanceID, dimensionName string) (ids map[string]string, err error) {
+	return map[string]string{}, m.checkForErrors()
 }
 
 func (m *Mock) CloneRelationships(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string) error {
 	return m.checkForErrors()
 }
 
-func (m *Mock) CloneRelationshipsFromIDs(ctx context.Context, attempt int, instanceID, dimensionName string, ids map[string]struct{}) error {
+func (m *Mock) CloneRelationshipsFromIDs(ctx context.Context, attempt int, instanceID, dimensionName string, ids map[string]string) error {
 	return m.checkForErrors()
 }
 
@@ -54,7 +58,7 @@ func (m *Mock) SetNumberOfChildren(ctx context.Context, attempt int, instanceID,
 	return m.checkForErrors()
 }
 
-func (m *Mock) SetNumberOfChildrenFromIDs(ctx context.Context, attempt int, ids map[string]struct{}) (err error) {
+func (m *Mock) SetNumberOfChildrenFromIDs(ctx context.Context, attempt int, ids map[string]string) (err error) {
 	return m.checkForErrors()
 }
 
@@ -62,7 +66,7 @@ func (m *Mock) RemoveCloneEdges(ctx context.Context, attempt int, instanceID, di
 	return m.checkForErrors()
 }
 
-func (m *Mock) RemoveCloneEdgesFromSourceIDs(ctx context.Context, attempt int, ids map[string]struct{}) (err error) {
+func (m *Mock) RemoveCloneEdgesFromSourceIDs(ctx context.Context, attempt int, ids map[string]string) (err error) {
 	return m.checkForErrors()
 }
 

--- a/mock/hierarchy.go
+++ b/mock/hierarchy.go
@@ -30,6 +30,10 @@ func (m *Mock) CreateHasCodeEdges(ctx context.Context, attempt int, codeListID s
 	return m.checkForErrors()
 }
 
+func (m *Mock) CloneOrderFromIDs(ctx context.Context, codeListID string, ids map[string]string) (err error) {
+	return m.checkForErrors()
+}
+
 func (m *Mock) CloneNodes(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string) error {
 	return m.checkForErrors()
 }

--- a/mock/hierarchy.go
+++ b/mock/hierarchy.go
@@ -18,12 +18,12 @@ func (m *Mock) GetCodesWithData(ctx context.Context, attempt int, instanceID, di
 	return []string{}, m.checkForErrors()
 }
 
-func (m *Mock) GetGenericHierarchyNodeIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs map[string]struct{}, err error) {
-	return map[string]struct{}{}, m.checkForErrors()
+func (m *Mock) GetGenericHierarchyNodeIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs map[string]string, err error) {
+	return map[string]string{}, m.checkForErrors()
 }
 
-func (m *Mock) GetGenericHierarchyAncestriesIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs map[string]struct{}, err error) {
-	return map[string]struct{}{}, m.checkForErrors()
+func (m *Mock) GetGenericHierarchyAncestriesIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs map[string]string, err error) {
+	return map[string]string{}, m.checkForErrors()
 }
 
 func (m *Mock) CloneNodes(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string) error {

--- a/neo4j/codelists.go
+++ b/neo4j/codelists.go
@@ -131,7 +131,7 @@ func (n *Neo4j) GetCodeDatasets(ctx context.Context, codeListID, edition string,
 		return nil, driver.ErrNotFound
 	}
 
-	datasets := make(mapper.Datasets, 0)
+	datasets := make(mapper.Datasets)
 	query := fmt.Sprintf(query.GetCodeDatasets, codeListID, edition, code)
 	if err := n.Read(query, mapper.CodesDatasets(datasets), false); err != nil {
 		return nil, err

--- a/neo4j/hierarchy_reader.go
+++ b/neo4j/hierarchy_reader.go
@@ -171,7 +171,12 @@ func (n *Neo4j) GetGenericHierarchyAncestriesIDs(ctx context.Context, attempt in
 	return map[string]string{}, driver.ErrNotImplemented
 }
 
+// CreateCodeEdges not implemented by Neo4j (new hierarchy build algorithm with order)
+func (n *Neo4j) CreateHasCodeEdges(ctx context.Context, attempt int, codeListID string, codesById map[string]string) (err error) {
+	return driver.ErrNotImplemented
+}
+
 // GetHierarchyNodeIDs not implemented by Neo4j (new hierarchy build algorithm)
-func (n *Neo4j) GetHierarchyNodeIDs(ctx context.Context, attempt int, instanceID, dimensionName string) (ids map[string]struct{}, err error) {
-	return map[string]struct{}{}, driver.ErrNotImplemented
+func (n *Neo4j) GetHierarchyNodeIDs(ctx context.Context, attempt int, instanceID, dimensionName string) (ids map[string]string, err error) {
+	return map[string]string{}, driver.ErrNotImplemented
 }

--- a/neo4j/hierarchy_reader.go
+++ b/neo4j/hierarchy_reader.go
@@ -3,6 +3,7 @@ package neo4j
 import (
 	"context"
 	"fmt"
+
 	"github.com/ONSdigital/dp-graph/v2/graph/driver"
 	"github.com/ONSdigital/dp-graph/v2/models"
 	"github.com/ONSdigital/dp-graph/v2/neo4j/mapper"
@@ -161,13 +162,13 @@ func (n *Neo4j) GetCodesWithData(ctx context.Context, attempt int, instanceID, d
 }
 
 // GetGenericHierarchyNodeIDs not implemented by Neo4j (new hierarchy build algorithm)
-func (n *Neo4j) GetGenericHierarchyNodeIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs map[string]struct{}, err error) {
-	return map[string]struct{}{}, driver.ErrNotImplemented
+func (n *Neo4j) GetGenericHierarchyNodeIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs map[string]string, err error) {
+	return map[string]string{}, driver.ErrNotImplemented
 }
 
 // GetGenericHierarchyAncestriesIDs not implemented by Neo4j (new hierarchy build algorithm)
-func (n *Neo4j) GetGenericHierarchyAncestriesIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs map[string]struct{}, err error) {
-	return map[string]struct{}{}, driver.ErrNotImplemented
+func (n *Neo4j) GetGenericHierarchyAncestriesIDs(ctx context.Context, attempt int, codeListID string, codes []string) (nodeIDs map[string]string, err error) {
+	return map[string]string{}, driver.ErrNotImplemented
 }
 
 // GetHierarchyNodeIDs not implemented by Neo4j (new hierarchy build algorithm)

--- a/neo4j/hierarchy_reader.go
+++ b/neo4j/hierarchy_reader.go
@@ -171,11 +171,6 @@ func (n *Neo4j) GetGenericHierarchyAncestriesIDs(ctx context.Context, attempt in
 	return map[string]string{}, driver.ErrNotImplemented
 }
 
-// CreateCodeEdges not implemented by Neo4j (new hierarchy build algorithm with order)
-func (n *Neo4j) CreateHasCodeEdges(ctx context.Context, attempt int, codeListID string, codesById map[string]string) (err error) {
-	return driver.ErrNotImplemented
-}
-
 // GetHierarchyNodeIDs not implemented by Neo4j (new hierarchy build algorithm)
 func (n *Neo4j) GetHierarchyNodeIDs(ctx context.Context, attempt int, instanceID, dimensionName string) (ids map[string]string, err error) {
 	return map[string]string{}, driver.ErrNotImplemented

--- a/neo4j/hierarchy_test.go
+++ b/neo4j/hierarchy_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"testing"
+
 	"github.com/ONSdigital/dp-graph/v2/neo4j/mapper"
 	"github.com/ONSdigital/dp-graph/v2/neo4j/query"
-	"testing"
 
 	"github.com/ONSdigital/dp-graph/v2/graph/driver"
 	graph "github.com/ONSdigital/dp-graph/v2/graph/driver"
@@ -20,7 +21,6 @@ import (
 )
 
 var (
-	q             string
 	instanceID    = "instanceID"
 	dimensionName = "dimensionName"
 	codeListID    = "codeListID"
@@ -79,7 +79,7 @@ func Test_CreateInstanceHierarchyConstraints_NeoErrExec(t *testing.T) {
 			})
 
 			Convey("Then the returned error should be that returned from the exec call", func() {
-				So(err, ShouldResemble, graph.ErrNonRetriable{errExec})
+				So(err, ShouldResemble, graph.ErrNonRetriable{WrappedErr: errExec})
 			})
 		})
 	})
@@ -105,7 +105,7 @@ func TestStore_CreateInstanceHierarchyConstraints_NeoExecRetry(t *testing.T) {
 			})
 
 			Convey("Then the returned error should wrap that returned from the exec call", func() {
-				So(err, ShouldResemble, graph.ErrAttemptsExceededLimit{transientNeoErr})
+				So(err, ShouldResemble, graph.ErrAttemptsExceededLimit{WrappedErr: transientNeoErr})
 			})
 		})
 	})
@@ -164,7 +164,7 @@ func TestStore_CloneNodes_NeoerrExec(t *testing.T) {
 			})
 
 			Convey("Then the returned error should be that returned from the exec call", func() {
-				So(err, ShouldResemble, graph.ErrNonRetriable{errExec})
+				So(err, ShouldResemble, graph.ErrNonRetriable{WrappedErr: errExec})
 			})
 		})
 	})
@@ -230,7 +230,7 @@ func TestStore_CloneRelationships_NeoErrExec(t *testing.T) {
 			})
 
 			Convey("Then the returned error should be that returned from the exec call", func() {
-				So(err, ShouldResemble, graph.ErrNonRetriable{errExec})
+				So(err, ShouldResemble, graph.ErrNonRetriable{WrappedErr: errExec})
 			})
 		})
 	})
@@ -290,7 +290,7 @@ func TestStore_SetNumberOfChildren_NeoErrExec(t *testing.T) {
 			})
 
 			Convey("Then the returned error should be that returned from the exec call", func() {
-				So(err, ShouldResemble, graph.ErrNonRetriable{errExec})
+				So(err, ShouldResemble, graph.ErrNonRetriable{WrappedErr: errExec})
 			})
 		})
 	})
@@ -349,7 +349,7 @@ func TestStore_SetHasData_NeoErrExec(t *testing.T) {
 			})
 
 			Convey("Then the returned error should be that returned from the exec call", func() {
-				So(err, ShouldResemble, graph.ErrNonRetriable{errExec})
+				So(err, ShouldResemble, graph.ErrNonRetriable{WrappedErr: errExec})
 			})
 		})
 	})
@@ -408,7 +408,7 @@ func TestStore_MarkNodesToRemain_NeoErrExec(t *testing.T) {
 			})
 
 			Convey("Then the returned error should be that returned from the exec call", func() {
-				So(err, ShouldResemble, graph.ErrNonRetriable{errExec})
+				So(err, ShouldResemble, graph.ErrNonRetriable{WrappedErr: errExec})
 			})
 		})
 	})
@@ -464,7 +464,7 @@ func TestStore_RemoveNodesNotMarkedToRemain_NeoErrExec(t *testing.T) {
 			})
 
 			Convey("Then the returned error should be that returned from the exec call", func() {
-				So(err, ShouldResemble, graph.ErrNonRetriable{errExec})
+				So(err, ShouldResemble, graph.ErrNonRetriable{WrappedErr: errExec})
 			})
 		})
 	})
@@ -520,7 +520,7 @@ func TestStore_RemoveRemainMarker_NeoErrExec(t *testing.T) {
 			})
 
 			Convey("Then the returned error should be that returned from the exec call", func() {
-				So(err, ShouldResemble, graph.ErrNonRetriable{errExec})
+				So(err, ShouldResemble, graph.ErrNonRetriable{WrappedErr: errExec})
 			})
 		})
 	})

--- a/neo4j/hierarchy_writer.go
+++ b/neo4j/hierarchy_writer.go
@@ -239,11 +239,11 @@ func (n *Neo4j) RemoveRemainMarker(ctx context.Context, attempt int, instanceID,
 	return nil
 }
 
-func (n *Neo4j) CloneNodesFromIDs(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string, ids map[string]struct{}, hasData bool) (err error) {
+func (n *Neo4j) CloneNodesFromIDs(ctx context.Context, attempt int, instanceID, codeListID, dimensionName string, ids map[string]string, hasData bool) (err error) {
 	return driver.ErrNotImplemented
 }
 
-func (n *Neo4j) CloneRelationshipsFromIDs(ctx context.Context, attempt int, instanceID, dimensionName string, ids map[string]struct{}) error {
+func (n *Neo4j) CloneRelationshipsFromIDs(ctx context.Context, attempt int, instanceID, dimensionName string, ids map[string]string) error {
 	return driver.ErrNotImplemented
 }
 
@@ -251,10 +251,10 @@ func (n *Neo4j) RemoveCloneEdges(ctx context.Context, attempt int, instanceID, d
 	return driver.ErrNotImplemented
 }
 
-func (n *Neo4j) RemoveCloneEdgesFromSourceIDs(ctx context.Context, attempt int, ids map[string]struct{}) (err error) {
+func (n *Neo4j) RemoveCloneEdgesFromSourceIDs(ctx context.Context, attempt int, ids map[string]string) (err error) {
 	return driver.ErrNotImplemented
 }
 
-func (n *Neo4j) SetNumberOfChildrenFromIDs(ctx context.Context, attempt int, ids map[string]struct{}) (err error) {
+func (n *Neo4j) SetNumberOfChildrenFromIDs(ctx context.Context, attempt int, ids map[string]string) (err error) {
 	return driver.ErrNotImplemented
 }

--- a/neo4j/hierarchy_writer.go
+++ b/neo4j/hierarchy_writer.go
@@ -247,6 +247,14 @@ func (n *Neo4j) CloneRelationshipsFromIDs(ctx context.Context, attempt int, inst
 	return driver.ErrNotImplemented
 }
 
+func (n *Neo4j) CreateHasCodeEdges(ctx context.Context, attempt int, codeListID string, codesById map[string]string) (err error) {
+	return driver.ErrNotImplemented
+}
+
+func (n *Neo4j) CloneOrderFromIDs(ctx context.Context, codeListID string, ids map[string]string) (err error) {
+	return driver.ErrNotImplemented
+}
+
 func (n *Neo4j) RemoveCloneEdges(ctx context.Context, attempt int, instanceID, dimensionName string) (err error) {
 	return driver.ErrNotImplemented
 }

--- a/neo4j/mapper/codes_test.go
+++ b/neo4j/mapper/codes_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/ONSdigital/dp-graph/v2/models"
 	"github.com/ONSdigital/golang-neo4j-bolt-driver/structures/graph"
-	"github.com/pkg/errors"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -14,7 +13,6 @@ var (
 	testCodeListID        = "666" // the number of the best \m/
 	testEdition           = "2018"
 	testCode              = "99"
-	errTest               = errors.New("error happened yo")
 	testNodeIdentity      = int64(666) // the number of the best \m/
 	testNodeValue         = "node-value"
 	testRelationshipLabel = "relationship label"

--- a/neo4j/mapper/datasets.go
+++ b/neo4j/mapper/datasets.go
@@ -59,7 +59,7 @@ func CodesDatasets(datasets Datasets) ResultMapper {
 		if !ok {
 			dataset = DatasetData{
 				DimensionLabel: dimensionLabel,
-				Editions:       make(DatasetEditions, 0),
+				Editions:       make(DatasetEditions),
 			}
 		}
 

--- a/neo4j/neo4j.go
+++ b/neo4j/neo4j.go
@@ -59,13 +59,13 @@ func (n *Neo4j) checkAttempts(err error, instanceID string, attempt int) error {
 		log.Event(ctx, "received an error from neo4j that cannot be retried", log.ERROR,
 			log.Data{"instance_id": instanceID, "error": err})
 
-		return graph.ErrNonRetriable{err}
+		return graph.ErrNonRetriable{WrappedErr: err}
 	}
 
 	time.Sleep(getSleepTime(attempt, 20*time.Millisecond))
 
 	if attempt >= n.maxRetries {
-		return graph.ErrAttemptsExceededLimit{err}
+		return graph.ErrAttemptsExceededLimit{WrappedErr: err}
 	}
 
 	return nil

--- a/neptune/hierarchy_test.go
+++ b/neptune/hierarchy_test.go
@@ -23,21 +23,23 @@ var (
 	testDimensionName = "aggregate"
 	testAttempt       = 1
 	testCodes         = []string{"cpih1dim1S90401", "cpih1dim1S90402"}
-	testIds           = map[string]struct{}{
-		"cpih1dim1aggid--cpih1dim1S90401": {},
-		"cpih1dim1aggid--cpih1dim1S90402": {}}
-	testAllIds = map[string]struct{}{
-		"cpih1dim1aggid--cpih1dim1S90401": {},
-		"cpih1dim1aggid--cpih1dim1S90402": {},
-		"cpih1dim1aggid--cpih1dim1G90400": {},
-		"cpih1dim1aggid--cpih1dim1T90000": {},
-		"cpih1dim1aggid--cpih1dim1A0":     {}}
-	testClonedIds = map[string]struct{}{
-		"62bab579-e923-7cb2-3be0-34d09dc0567b": {},
-		"acbab579-e923-87df-e59a-9daf2ffed388": {},
-		"b6bab57a-604d-8a7f-59f5-1d496c9b3ca5": {},
-		"08bab57a-604d-9cd9-492f-e879cee05502": {},
-		"6cbab57a-604d-f176-9370-c60c19369801": {},
+	testIds           = map[string]string{
+		"cpih1dim1aggid--cpih1dim1S90401": "",
+		"cpih1dim1aggid--cpih1dim1S90402": "",
+	}
+	testAllIds = map[string]string{
+		"cpih1dim1aggid--cpih1dim1S90401": "",
+		"cpih1dim1aggid--cpih1dim1S90402": "",
+		"cpih1dim1aggid--cpih1dim1G90400": "",
+		"cpih1dim1aggid--cpih1dim1T90000": "",
+		"cpih1dim1aggid--cpih1dim1A0":     "",
+	}
+	testClonedIds = map[string]string{
+		"62bab579-e923-7cb2-3be0-34d09dc0567b": "",
+		"acbab579-e923-87df-e59a-9daf2ffed388": "",
+		"b6bab57a-604d-8a7f-59f5-1d496c9b3ca5": "",
+		"08bab57a-604d-9cd9-492f-e879cee05502": "",
+		"6cbab57a-604d-f176-9370-c60c19369801": "",
 	}
 )
 
@@ -326,7 +328,7 @@ func TestNeptuneDB_CloneNodesFromID(t *testing.T) {
 		})
 
 		Convey("When CloneNodes is called with an empty map of IDs", func() {
-			err := db.CloneNodesFromIDs(ctx, testAttempt, testInstanceID, testCodeListID, testDimensionName, map[string]struct{}{}, true)
+			err := db.CloneNodesFromIDs(ctx, testAttempt, testInstanceID, testCodeListID, testDimensionName, map[string]string{}, true)
 
 			Convey("Then no error is returned", func() {
 				So(err, ShouldBeNil)
@@ -403,7 +405,7 @@ func TestNeptuneDB_CloneRelationshipsFromIDs(t *testing.T) {
 		})
 
 		Convey("When CloneRelationShips is called with an empty map of IDs", func() {
-			err := db.CloneRelationshipsFromIDs(ctx, testAttempt, testInstanceID, testDimensionName, map[string]struct{}{})
+			err := db.CloneRelationshipsFromIDs(ctx, testAttempt, testInstanceID, testDimensionName, map[string]string{})
 
 			Convey("Then no error is returned", func() {
 				So(err, ShouldBeNil)
@@ -472,7 +474,7 @@ func TestNeptuneDB_RemoveCloneEdgesFromSourceIDs(t *testing.T) {
 		})
 
 		Convey("When RemoveCloneEdgesFromSourceIDs is called with an empty map of IDs", func() {
-			err := db.RemoveCloneEdgesFromSourceIDs(ctx, testAttempt, map[string]struct{}{})
+			err := db.RemoveCloneEdgesFromSourceIDs(ctx, testAttempt, map[string]string{})
 
 			Convey("Then no error is returned", func() {
 				So(err, ShouldBeNil)
@@ -566,7 +568,7 @@ func TestNeptuneDB_SetNumberOfChildrenFromIDs(t *testing.T) {
 		})
 
 		Convey("When SetNumberOfChildrenFromIDs is called with an empty map of IDs", func() {
-			err := db.SetNumberOfChildrenFromIDs(ctx, testAttempt, map[string]struct{}{})
+			err := db.SetNumberOfChildrenFromIDs(ctx, testAttempt, map[string]string{})
 
 			Convey("Then no error is returned", func() {
 				So(err, ShouldBeNil)

--- a/neptune/observation_test.go
+++ b/neptune/observation_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ONSdigital/dp-graph/v2/models"
 	"strings"
 	"testing"
+
+	"github.com/ONSdigital/dp-graph/v2/models"
 
 	"github.com/ONSdigital/dp-graph/v2/neptune/internal"
 	"github.com/ONSdigital/dp-graph/v2/neptune/query"
@@ -79,7 +80,7 @@ func Test_StreamCSVRows(t *testing.T) {
 		db := mockDB(poolMock)
 
 		Convey("When StreamCSVRows is called", func() {
-			stream, err := db.StreamCSVRows(nil, "", "", nil, nil)
+			stream, err := db.StreamCSVRows(ctx, "", "", nil, nil)
 
 			Convey("Then an error is returned", func() {
 				So(stream, ShouldBeNil)
@@ -106,7 +107,7 @@ func Test_StreamCSVRows(t *testing.T) {
 		}
 
 		Convey("When StreamCSVRows is called", func() {
-			stream, err := db.StreamCSVRows(nil, instanceID, "", filter, nil)
+			stream, err := db.StreamCSVRows(ctx, instanceID, "", filter, nil)
 
 			Convey("Then no error should be returned", func() {
 				So(stream, ShouldNotBeNil)

--- a/neptune/query/query.go
+++ b/neptune/query/query.go
@@ -87,9 +87,14 @@ const (
 		`.addE('clone_of').to('old')` +
 		`.select('new')`
 
-	// CloneHierarchyNodesFromIDs traverses the provided node IDs and creates a clone for each one
-	// by cloning 'code' and 'label' properties, setting 'hasData' to the provided boolean value, setting 'code_list' to the provided value,
-	// and creating a 'clone_of' edge between the new node and the original one.
+	// CloneHierarchyNodesFromIDs traverses the provided node IDs and creates a clone for each one, thus:
+	// 1. get generic hierarchy nodes from IDs
+	// 2. create a new hierarchy node for the provided 'instance' and 'dimensionName'
+	// 3. copy 'code' property from the generic hierarchy node to the new node
+	// 4. copy 'label' from the generic hierarchy node to the new node
+	// 5. set 'hasData' to true or false, according to the provided value
+	// 6. set 'code_list' property to the provided value
+	// 7. create a 'clone_of' edge between the new node and the generic node
 	CloneHierarchyNodesFromIDs = `g.V(%s).as('old')` +
 		`.addV('_hierarchy_node_%s_%s')` +
 		`.property(single,'code',select('old').values('code'))` +
@@ -98,8 +103,14 @@ const (
 		`.property('code_list','%s').as('new')` +
 		`.addE('clone_of').to('old')`
 
-	// CloneOrderFromIDs traverses the provided generic hierarchy nodeIDs and obtains the associated code order defined in the 'usedBy' edge
-	// then sets the order value as a property to its clones. As the 'clone_of' edge only exists during the cloning process, the performance will not degrade with the number of clones.
+	// CloneOrderFromIDs copies the order property from the code of a generic hierarchy node to its clone, thus:
+	// 1. get generic hierarchy nodes from IDs
+	// 2. traverse 'hasCode' edge to go to the corresponding code node
+	//    (this edge exists so that the query can run quickly, up to x1000 quicker than nested queries)
+	// 3. traverse 'usedBy' edge that points to the codeList that we are using
+	// 4. select 'order' property from the 'usedBy' edge
+	// 5. go back to the generic hierarchy node 'old', and traverse 'clone_of' edge to go to the cloned hierarchy node
+	// 6. set 'order' property to the cloned hierarchy node
 	CloneOrderFromIDs = `g.V(%s).as('old')` +
 		`.out('hasCode')` +
 		`.outE('usedBy').where(otherV().hasLabel('_code_list').has('_code_list', 'listID', '%s'))` +

--- a/neptune/query/query.go
+++ b/neptune/query/query.go
@@ -98,6 +98,15 @@ const (
 		`.property('code_list','%s').as('new')` +
 		`.addE('clone_of').to('old')`
 
+	// CloneOrderFromIDs traverses the provided generic hierarchy nodeIDs and obtains the associated code order defined in the 'usedBy' edge
+	// then sets the order value as a property to its clones. As the 'clone_of' edge only exists during the cloning process, the performance will not degrade with the number of clones.
+	CloneOrderFromIDs = `g.V(%s).as('old')` +
+		`.out('hasCode')` +
+		`.outE('usedBy').where(otherV().hasLabel('_code_list').has('_code_list', 'listID', '%s'))` +
+		`.values('order').as('o')` +
+		`.select('old').in('clone_of')` +
+		`.property(single,'order', select('o'))`
+
 	// CountHierarchyNodes returns the number of hierarchy nodes for the provided instanceID and dimensionName
 	CountHierarchyNodes = `g.V().hasLabel('_hierarchy_node_%s_%s').count()`
 

--- a/neptune/query/query.go
+++ b/neptune/query/query.go
@@ -70,9 +70,9 @@ const (
 	GetGenericHierarchyAncestryIDs = `g.V().hasLabel('_generic_hierarchy_node_%s').has('code',within(%s)).repeat(out('hasParent')).emit().as('gh')` +
 		`.id().as('node_id').select('gh').values('code').as('node_code').select('gh').select('node_id', 'node_code')`
 
-	// crete 'hasCode' edges from generic hierarchy nodes to corresponding code nodes, only if they do not exist already
-	CreateGenericHierarchyHasCodeEdgesFromIDs = `g.V().hasLabel('_generic_hierarchy_node_countries-and-territories').as('h').
-		coalesce(__.outE('hasCode'), __.addE('hasCode').to(g.V().hasLabel('_code').has('value', select('h').values('code'))))`
+	// crete 'hasCode' edge from a generic hierarchy node to the provided code node, only if it does not exist already
+	CreateHasCodeEdge = `g.V().hasLabel('_code').has('value', '%s').as('dest')` +
+		`.V('%s').coalesce(__.outE('hasCode'), __.addE('hasCode').to(select('dest')))`
 
 	// GetHierarchyNodeIDs gets the IDs of the cloned hierarchy nodes for a particular instanceID and dimensionName
 	GetHierarchyNodeIDs = `g.V().hasLabel('_hierarchy_node_%s_%s').id()`

--- a/neptune/utils.go
+++ b/neptune/utils.go
@@ -6,17 +6,17 @@ import (
 )
 
 // batchProcessor defines a generic function type to process a batch (array of strings) and may return a result (array of strings) and an error.
-type batchProcessor = func([]string) ([]string, error)
+type batchProcessor = func([]string) (map[string]interface{}, error)
 
 // processInConcurrentBatches splits the provided items in batches and calls processBatch for each batch batch, concurrently.
 // The results of the batch Processor functions, if provided, are aggregated as unique items and returned.
-func processInConcurrentBatches(items []string, processBatch batchProcessor, batchSize, maxWorkers int) (result map[string]struct{}, numChunks int, errs []error) {
+func processInConcurrentBatches(items []string, processBatch batchProcessor, batchSize, maxWorkers int) (result map[string]interface{}, numChunks int, errs []error) {
 	wg := sync.WaitGroup{}
 	chWait := make(chan struct{})
 	chErr := make(chan error)
 	chSemaphore := make(chan struct{}, maxWorkers)
 
-	result = make(map[string]struct{})
+	result = make(map[string]interface{})
 	lockResult := sync.Mutex{}
 
 	// worker add delta to workgroup and acquire semaphore
@@ -40,8 +40,8 @@ func processInConcurrentBatches(items []string, processBatch batchProcessor, bat
 			return
 		}
 		lockResult.Lock()
-		for _, resItem := range res {
-			result[resItem] = struct{}{}
+		for k, v := range res {
+			result[k] = v
 		}
 		lockResult.Unlock()
 	}

--- a/neptune/utils_test.go
+++ b/neptune/utils_test.go
@@ -14,9 +14,9 @@ func TestCreateMap(t *testing.T) {
 		a := []string{"0", "1", "2", "2"}
 		b := []string{"0", "3", "3"}
 
-		Convey("Then createMap returns a map of empty structs where the keys are the union of all array items", func() {
-			m := createInterfaceMapFromArrays(a, b)
-			So(m, ShouldResemble, map[string]interface{}{"0": struct{}{}, "1": struct{}{}, "2": struct{}{}, "3": struct{}{}})
+		Convey("Then createMap returns a map of empty strings where the keys are the union of all array items (unique)", func() {
+			m := createMapFromArrays(a, b)
+			So(m, ShouldResemble, map[string]string{"0": "", "1": "", "2": "", "3": ""})
 		})
 	})
 }
@@ -24,7 +24,7 @@ func TestCreateMap(t *testing.T) {
 func TestCreateArray(t *testing.T) {
 
 	Convey("Given an empty struct map", t, func() {
-		m := map[string]interface{}{"0": nil, "1": nil, "2": nil}
+		m := map[string]string{"0": "", "1": "", "2": ""}
 
 		Convey("Then createArray returns an array of strings containing the keys, in any order", func() {
 			a := createArray(m)
@@ -51,7 +51,7 @@ func TestUnique(t *testing.T) {
 	})
 }
 
-func validateAllItems(expectedItems map[string]interface{}, processedChunks []map[string]interface{}) {
+func validateAllItems(expectedItems map[string]string, processedChunks []map[string]string) {
 	for _, chunk := range processedChunks {
 		for k, v := range chunk {
 			expectedVal, found := expectedItems[k]
@@ -64,9 +64,9 @@ func validateAllItems(expectedItems map[string]interface{}, processedChunks []ma
 func TestProcessInBatches(t *testing.T) {
 
 	Convey("Given an array of 10 items and a mock chunk processor function", t, func() {
-		items := map[string]interface{}{"0": 0, "1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8, "9": 9}
-		processedChunks := []map[string]interface{}{}
-		processor := func(chunk map[string]interface{}) { processedChunks = append(processedChunks, chunk) }
+		items := map[string]string{"0": "0val", "1": "1val", "2": "2val", "3": "3val", "4": "4val", "5": "5val", "6": "6val", "7": "7val", "8": "8val", "9": "9val"}
+		processedChunks := []map[string]string{}
+		processor := func(chunk map[string]string) { processedChunks = append(processedChunks, chunk) }
 
 		Convey("Then processing in chunks of size 5 results in the function being called twice with the expected chunks", func() {
 			numChunks := processInBatches(items, processor, 5)
@@ -91,22 +91,22 @@ func TestProcessInBatches(t *testing.T) {
 func TestInConcurrentBatches(t *testing.T) {
 
 	Convey("Given an array of 10 items", t, func() {
-		items := map[string]interface{}{"0": 0, "1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8, "9": 9}
-		processedChunks := []map[string]interface{}{}
+		items := map[string]string{"0": "0val", "1": "1val", "2": "2val", "3": "3val", "4": "4val", "5": "5val", "6": "6val", "7": "7val", "8": "8val", "9": "9val"}
+		processedChunks := []map[string]string{}
 		lock := sync.Mutex{}
 
 		Convey("And a successful mock chunk processor function that returns an empty map", func() {
-			processor := func(chunk map[string]interface{}) (map[string]interface{}, error) {
+			processor := func(chunk map[string]string) (map[string]string, error) {
 				defer lock.Unlock()
 				lock.Lock()
 				processedChunks = append(processedChunks, chunk)
-				return make(map[string]interface{}), nil
+				return make(map[string]string), nil
 			}
 
 			Convey("Then processing the chunks concurrently results in an aggregated empty array, "+
 				"the expected number of chunks and no error being returned", func() {
 				result, numChunks, errs := processInConcurrentBatches(items, processor, 5, 150)
-				So(result, ShouldResemble, make(map[string]interface{}))
+				So(result, ShouldResemble, make(map[string]string))
 				So(numChunks, ShouldEqual, 2)
 				So(errs, ShouldBeNil)
 				So(processedChunks, ShouldHaveLength, 2)
@@ -117,16 +117,16 @@ func TestInConcurrentBatches(t *testing.T) {
 
 			Convey("And an erroring mock chunk processor function", func() {
 				testErr := errors.New("testErr")
-				processor := func(chunk map[string]interface{}) (map[string]interface{}, error) {
+				processor := func(chunk map[string]string) (map[string]string, error) {
 					defer lock.Unlock()
 					lock.Lock()
 					processedChunks = append(processedChunks, chunk)
-					return map[string]interface{}{"shouldBeIgnored": true}, testErr
+					return map[string]string{"shouldBeIgnored": "true"}, testErr
 				}
 
 				Convey("Then processing the chunks concurrently results in all errors being returned", func() {
 					result, numChunks, errs := processInConcurrentBatches(items, processor, 5, 150)
-					So(result, ShouldResemble, make(map[string]interface{}))
+					So(result, ShouldResemble, make(map[string]string))
 					So(numChunks, ShouldEqual, 2)
 					So(errs, ShouldResemble, []error{testErr, testErr})
 					So(processedChunks, ShouldHaveLength, 2)

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -71,7 +71,7 @@ func Do(
 // sleep waits for a calculated time. The time increases based on the attempt number. The function returns
 // immediately if the given context is cancelled.
 func sleep(ctx context.Context, attempt int, retryTime time.Duration) error {
-	pingChan := make(chan struct{}, 0)
+	pingChan := make(chan struct{})
 
 	go func() {
 		time.Sleep(getSleepTime(attempt, retryTime))


### PR DESCRIPTION
### What

Added queries to copy code order to hierarchy nodes
- get generic node IDs now returns a map of {node_id: code}
- new query to create an edge between a generic node and the corresponding code node, if it does not exist. Unfortunately this query cannot be 'batched' because dynamically finding the code in the same query is not efficient, so we need to do a query per edge (we still run them in parallel, according to 'max_workers')
- New query to clone orders from generic node IDs to hierarchy nodes being cloned. This is the subgraph used for this query:
`
[hierarchy_node]-clone_of->[generic_node]-hasCode->[code_node]-usedBy->[code_list_node]
`
  - starting with the generic node
  - traverse `hasCode` to the code node
  - traverse to `usedBy` edge that points to the codeList node that we are interested in
  - select the order proverty from the edge
  - go back to the generic node
  - traverse `clone_of` edge backwards
  - set order property to hierarchy node

- Added section in spike to document the implemented logic: https://docs.google.com/document/d/1URBpLNCTm4f8rHVARq1wqZCP0AuyPygrCN-2L5Hqqu8

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

- (optional) I tested the queries using the following unit tests with a real connection locally, and then validating the resulting nodes using the gremlin console (files attached to Trello card) 

 
### Who can review

Anyone