### PR TITLE
map order property from hierarchy nodes, if present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,18 +5,10 @@ all: audit test build
 audit:
 	go list -json -m all | nancy sleuth --exclude-vulnerability-file ./.nancy-ignore
 
-.PHONY: build
-build:
-	go build ./...
-
 .PHONY: test
 test:
 	go test -race -cover ./...
 
-audit:
-	go list -json -m all | nancy -v sleuth --exclude-vulnerability-file ./.nancy-ignore
-.PHONY: audit
-
+.PHONY: build
 build:
 	go build ./...
-.PHONY: build

--- a/models/hierarchy.go
+++ b/models/hierarchy.go
@@ -6,6 +6,7 @@ type HierarchyResponse struct {
 	Label        string
 	Children     []*HierarchyElement
 	NoOfChildren int64
+	Order        int64
 	HasData      bool
 	Breadcrumbs  []*HierarchyElement
 }
@@ -15,5 +16,6 @@ type HierarchyElement struct {
 	ID           string
 	Label        string
 	NoOfChildren int64
+	Order        int64
 	HasData      bool
 }

--- a/models/hierarchy.go
+++ b/models/hierarchy.go
@@ -6,7 +6,7 @@ type HierarchyResponse struct {
 	Label        string
 	Children     []*HierarchyElement
 	NoOfChildren int64
-	Order        int64
+	Order        *int64 // nil if order property not present
 	HasData      bool
 	Breadcrumbs  []*HierarchyElement
 }
@@ -16,6 +16,6 @@ type HierarchyElement struct {
 	ID           string
 	Label        string
 	NoOfChildren int64
-	Order        int64
+	Order        *int64 // nil if order property not present
 	HasData      bool
 }

--- a/neptune/hierarchy_test.go
+++ b/neptune/hierarchy_test.go
@@ -73,7 +73,10 @@ func TestNeptuneDB_GetCodesWithData(t *testing.T) {
 
 func TestNeptuneDB_HierarchyExists(t *testing.T) {
 
-	vertex := internal.MakeHierarchyVertex("vertex-label", "code", "label", 1, true)
+	vertex, err := internal.MakeHierarchyVertex("vertex-label", "code", "label", 1, true)
+	if err != nil {
+		t.Fail()
+	}
 
 	Convey("Given a neptune DB that returns a single hierarchy node", t, func() {
 

--- a/neptune/internal/mockpoolutils.go
+++ b/neptune/internal/mockpoolutils.go
@@ -204,6 +204,10 @@ func MakeHierarchyVertex(vertexLabel, code, codeLabel string, numberOfChildren i
 	return vertex
 }
 
+func SetOrder(vertex *graphson.Vertex, order int) {
+	setVertexTypedProperty("g:Int64", vertex, "order", map[string]interface{}{"@type": "g:Int64", "@value": float64(order)})
+}
+
 /*
 makeVertex makes a graphson.Vertex of a given type (e.g. "_code_list").
 */

--- a/neptune/internal/mockpoolutils.go
+++ b/neptune/internal/mockpoolutils.go
@@ -195,17 +195,32 @@ var ReturnNodeAncestryIDs = func(query string, bindings map[string]string, rebin
 	return ids, nil
 }
 
-func MakeHierarchyVertex(vertexLabel, code, codeLabel string, numberOfChildren int, hasData bool) graphson.Vertex {
+func MakeHierarchyVertex(vertexLabel, code, codeLabel string, numberOfChildren float64, hasData bool) (graphson.Vertex, error) {
+	if numberOfChildren < 0 {
+		return graphson.Vertex{}, errors.New("numberOfChildren should be positive")
+	}
+	if numberOfChildren != float64(int64(numberOfChildren)) {
+		return graphson.Vertex{}, errors.New("numberOfChildren should not have decimals")
+	}
+
 	vertex := makeVertex(vertexLabel)
 	setVertexStringProperty(&vertex, "code", code)
 	setVertexStringProperty(&vertex, "label", codeLabel)
-	setVertexTypedProperty("g:Int64", &vertex, "numberOfChildren", map[string]interface{}{"@type": "g:Int64", "@value": float64(numberOfChildren)})
+	setVertexTypedProperty("g:Int64", &vertex, "numberOfChildren", map[string]interface{}{"@type": "g:Int64", "@value": numberOfChildren})
 	setVertexTypedProperty("bool", &vertex, "hasData", hasData)
-	return vertex
+	return vertex, nil
 }
 
-func SetOrder(vertex *graphson.Vertex, order int) {
-	setVertexTypedProperty("g:Int64", vertex, "order", map[string]interface{}{"@type": "g:Int64", "@value": float64(order)})
+func SetOrder(vertex *graphson.Vertex, order float64) error {
+	if order < 0 {
+		return errors.New("order should be positive")
+	}
+	if order != float64(int64(order)) {
+		return errors.New("order should not have decimals")
+	}
+
+	setVertexTypedProperty("g:Int64", vertex, "order", map[string]interface{}{"@type": "g:Int64", "@value": order})
+	return nil
 }
 
 /*

--- a/neptune/mapper.go
+++ b/neptune/mapper.go
@@ -40,6 +40,14 @@ func (n *NeptuneDB) buildHierarchyNode(v graphson.Vertex, instanceID, dimension 
 		log.Event(ctx, "bad hasData", log.ERROR, logData, log.Error(err))
 		return
 	}
+	if res.Order, err = v.GetPropertyInt64("order"); err != nil {
+		if err != graphson.ErrorPropertyNotFound {
+			log.Event(ctx, "bad order", log.ERROR, logData, log.Error(err))
+			return
+		}
+		log.Event(ctx, "order not defined for this hierarchy node", log.INFO, logData)
+		err = nil
+	}
 	// Fetch new data from the database concerned with the node's children.
 	if res.NoOfChildren > 0 && instanceID != "" {
 
@@ -140,6 +148,14 @@ func convertVertexToElement(v graphson.Vertex) (res *models.HierarchyElement, er
 	if res.HasData, err = v.GetPropertyBool("hasData"); err != nil {
 		log.Event(ctx, "bad hasData", log.ERROR, logData, log.Error(err))
 		return
+	}
+	if res.Order, err = v.GetPropertyInt64("order"); err != nil {
+		if err != graphson.ErrorPropertyNotFound {
+			log.Event(ctx, "bad order", log.ERROR, logData, log.Error(err))
+			return
+		}
+		log.Event(ctx, "order not defined for this hierarchy node", log.INFO, logData)
+		err = nil
 	}
 	return
 }

--- a/neptune/mapper_test.go
+++ b/neptune/mapper_test.go
@@ -16,11 +16,14 @@ func Test_buildHierarchyNode(t *testing.T) {
 		poolMock := &internal.NeptunePoolMock{}
 		db := mockDB(poolMock)
 
-		expectedLabel := "code-label"
-		expectedCode := "code"
-		expectedHasData := true
-		var expectedNumberOfChildren float64 = 0
-		vertex, err := internal.MakeHierarchyVertex("vertex-label", expectedCode, expectedLabel, expectedNumberOfChildren, expectedHasData)
+		var (
+			expectedLabel                    = "code-label"
+			expectedCode                     = "code"
+			expectedHasData                  = true
+			numberOfChildren         float64 = 0
+			expectedNumberOfChildren int64   = 0
+		)
+		vertex, err := internal.MakeHierarchyVertex("vertex-label", expectedCode, expectedLabel, numberOfChildren, expectedHasData)
 		if err != nil {
 			t.Fail()
 		}
@@ -37,7 +40,7 @@ func Test_buildHierarchyNode(t *testing.T) {
 					So(*hierarchyNode, ShouldResemble, models.HierarchyResponse{
 						ID:           expectedCode,
 						Label:        expectedLabel,
-						NoOfChildren: int64(expectedNumberOfChildren),
+						NoOfChildren: expectedNumberOfChildren,
 						HasData:      expectedHasData,
 					})
 				})
@@ -45,8 +48,12 @@ func Test_buildHierarchyNode(t *testing.T) {
 		})
 
 		Convey("Where the hierarchy node has an order property", func() {
-			var expectedOrder float64 = 123
-			if err := internal.SetOrder(&vertex, expectedOrder); err != nil {
+			var (
+				order         float64 = 123
+				expectedOrder int64   = 123
+			)
+
+			if err := internal.SetOrder(&vertex, order); err != nil {
 				t.Fail()
 			}
 
@@ -57,9 +64,9 @@ func Test_buildHierarchyNode(t *testing.T) {
 					So(*hierarchyNode, ShouldResemble, models.HierarchyResponse{
 						ID:           expectedCode,
 						Label:        expectedLabel,
-						NoOfChildren: int64(expectedNumberOfChildren),
+						NoOfChildren: expectedNumberOfChildren,
 						HasData:      expectedHasData,
-						Order:        int64(expectedOrder),
+						Order:        &expectedOrder,
 					})
 				})
 			})

--- a/neptune/mapper_test.go
+++ b/neptune/mapper_test.go
@@ -3,6 +3,7 @@ package neptune
 import (
 	"testing"
 
+	"github.com/ONSdigital/dp-graph/v2/models"
 	"github.com/ONSdigital/dp-graph/v2/neptune/internal"
 	"github.com/ONSdigital/graphson"
 	. "github.com/smartystreets/goconvey/convey"
@@ -25,16 +26,37 @@ func Test_buildHierarchyNode(t *testing.T) {
 		dimension := "dimension"
 		instanceID := "instance-id"
 
-		Convey("When buildHierarchyNode is called", func() {
+		Convey("Where the hierarchy node does not have an order property", func() {
+			Convey("When buildHierarchyNode is called", func() {
+				hierarchyNode, err := db.buildHierarchyNode(vertex, instanceID, dimension, wantBreadcrumbs)
+				Convey("Then the expected values are mapped onto the returned hierarchy response", func() {
+					So(err, ShouldBeNil)
+					So(*hierarchyNode, ShouldResemble, models.HierarchyResponse{
+						ID:           expectedCode,
+						Label:        expectedLabel,
+						NoOfChildren: int64(expectedNumberOfChildren),
+						HasData:      expectedHasData,
+					})
+				})
+			})
+		})
 
-			hierarchyNode, err := db.buildHierarchyNode(vertex, instanceID, dimension, wantBreadcrumbs)
+		Convey("Where the hierarchy node has an order property", func() {
+			expectedOrder := 123
+			internal.SetOrder(&vertex, expectedOrder)
 
-			Convey("Then the expected values are mapped onto the returned hierarchy response", func() {
-				So(err, ShouldBeNil)
-				So(hierarchyNode.ID, ShouldEqual, expectedCode)
-				So(hierarchyNode.Label, ShouldEqual, expectedLabel)
-				So(hierarchyNode.NoOfChildren, ShouldEqual, expectedNumberOfChildren)
-				So(hierarchyNode.HasData, ShouldEqual, expectedHasData)
+			Convey("When buildHierarchyNode is called", func() {
+				hierarchyNode, err := db.buildHierarchyNode(vertex, instanceID, dimension, wantBreadcrumbs)
+				Convey("Then the expected values are mapped onto the returned hierarchy response", func() {
+					So(err, ShouldBeNil)
+					So(*hierarchyNode, ShouldResemble, models.HierarchyResponse{
+						ID:           expectedCode,
+						Label:        expectedLabel,
+						NoOfChildren: int64(expectedNumberOfChildren),
+						HasData:      expectedHasData,
+						Order:        int64(expectedOrder),
+					})
+				})
 			})
 		})
 	})
@@ -97,11 +119,13 @@ func Test_buildHierarchyNode(t *testing.T) {
 				})
 
 				Convey("Then the expected values are mapped onto the returned child nodes", func() {
-					So(len(hierarchyNode.Children), ShouldEqual, 1)
-					So(hierarchyNode.Children[0].NoOfChildren, ShouldEqual, expectedNumberOfChildren)
-					So(hierarchyNode.Children[0].ID, ShouldEqual, expectedCode)
-					So(hierarchyNode.Children[0].Label, ShouldEqual, expectedLabel)
-					So(hierarchyNode.Children[0].HasData, ShouldEqual, expectedHasData)
+					So(hierarchyNode.Children, ShouldHaveLength, 1)
+					So(*hierarchyNode.Children[0], ShouldResemble, models.HierarchyElement{
+						NoOfChildren: int64(expectedNumberOfChildren),
+						ID:           expectedCode,
+						Label:        expectedLabel,
+						HasData:      expectedHasData,
+					})
 				})
 			})
 		})
@@ -132,11 +156,13 @@ func Test_buildHierarchyNode(t *testing.T) {
 				})
 
 				Convey("Then the expected values are mapped onto the returned child nodes", func() {
-					So(len(hierarchyNode.Children), ShouldEqual, 1)
-					So(hierarchyNode.Children[0].NoOfChildren, ShouldEqual, expectedNumberOfChildren)
-					So(hierarchyNode.Children[0].ID, ShouldEqual, expectedCode)
-					So(hierarchyNode.Children[0].Label, ShouldEqual, expectedLabel)
-					So(hierarchyNode.Children[0].HasData, ShouldEqual, expectedHasData)
+					So(hierarchyNode.Children, ShouldHaveLength, 1)
+					So(*hierarchyNode.Children[0], ShouldResemble, models.HierarchyElement{
+						NoOfChildren: int64(expectedNumberOfChildren),
+						ID:           expectedCode,
+						Label:        expectedLabel,
+						HasData:      expectedHasData,
+					})
 				})
 			})
 		})

--- a/neptune/mapper_test.go
+++ b/neptune/mapper_test.go
@@ -19,8 +19,11 @@ func Test_buildHierarchyNode(t *testing.T) {
 		expectedLabel := "code-label"
 		expectedCode := "code"
 		expectedHasData := true
-		expectedNumberOfChildren := 0
-		vertex := internal.MakeHierarchyVertex("vertex-label", expectedCode, expectedLabel, expectedNumberOfChildren, expectedHasData)
+		var expectedNumberOfChildren float64 = 0
+		vertex, err := internal.MakeHierarchyVertex("vertex-label", expectedCode, expectedLabel, expectedNumberOfChildren, expectedHasData)
+		if err != nil {
+			t.Fail()
+		}
 
 		wantBreadcrumbs := false
 		dimension := "dimension"
@@ -42,8 +45,10 @@ func Test_buildHierarchyNode(t *testing.T) {
 		})
 
 		Convey("Where the hierarchy node has an order property", func() {
-			expectedOrder := 123
-			internal.SetOrder(&vertex, expectedOrder)
+			var expectedOrder float64 = 123
+			if err := internal.SetOrder(&vertex, expectedOrder); err != nil {
+				t.Fail()
+			}
 
 			Convey("When buildHierarchyNode is called", func() {
 				hierarchyNode, err := db.buildHierarchyNode(vertex, instanceID, dimension, wantBreadcrumbs)
@@ -64,10 +69,10 @@ func Test_buildHierarchyNode(t *testing.T) {
 	Convey("Given a hierarchy node with child nodes", t, func() {
 		// expected paramters for neptune pool mock
 		var (
-			expectedLabel            = "child-label"
-			expectedCode             = "child-code"
-			expectedHasData          = true
-			expectedNumberOfChildren = 1
+			expectedLabel                    = "child-label"
+			expectedCode                     = "child-code"
+			expectedHasData                  = true
+			expectedNumberOfChildren float64 = 1
 		)
 
 		// expected gremlin queries
@@ -81,13 +86,18 @@ func Test_buildHierarchyNode(t *testing.T) {
 		// mock the database to return a single child node
 		poolMock := &internal.NeptunePoolMock{
 			GetFunc: func(query string, bindings map[string]string, rebindings map[string]string) (vertices []graphson.Vertex, err error) {
-				return []graphson.Vertex{
-					internal.MakeHierarchyVertex("vertex-label", expectedCode, expectedLabel, expectedNumberOfChildren, expectedHasData),
-				}, nil
+				vertex, err := internal.MakeHierarchyVertex("vertex-label", expectedCode, expectedLabel, expectedNumberOfChildren, expectedHasData)
+				if err != nil {
+					t.Fail()
+				}
+				return []graphson.Vertex{vertex}, nil
 			},
 		}
 
-		vertex := internal.MakeHierarchyVertex("vertex-label", "code", "label", 1, true)
+		vertex, err := internal.MakeHierarchyVertex("vertex-label", "code", "label", 1, true)
+		if err != nil {
+			t.Fail()
+		}
 
 		wantBreadcrumbs := true
 		dimension := "dimension"


### PR DESCRIPTION
### What

In order to determine the order among hierarchy nodes, the callers of hierarchy API would need the order value, and not only the items sorted by order (for example, if we want to flatten hierarchy nodes, we need to know the order between items in different layers of the hierarchy)

In this PR, the order value in the hierarchy nodes is mapped to the response (if present, otherwise it is ignored).

Trello card for more details: https://trello.com/c/SmZAgSkp/5048-display-hierarchies-in-filter-journey-in-a-consistent-order

### How to review

- Make sure code changes make sense
- Make sure unit tests pass
- (info only) I tested this PR against develop Neptune cluster, using the following Hierarchy API calls:
```
- http://localhost:22600/hierarchies/0e372936-051c-401e-a635-9ae85f1fbb39/standardindustrialclassification -> returns order for parent and children
- http://localhost:22600/hierarchies/76f512ee-eeb7-4b95-a8a5-b89eb48fb087/aggregate -> doesn't return order for any node
```

### Who can review

Anyone