### PR TITLE
Bug fix: fixed query to obtain the code node. 

### DIFF
--- a/neptune/hierarchy_test.go
+++ b/neptune/hierarchy_test.go
@@ -313,9 +313,9 @@ func TestNeptuneDB_CreateHasCodeEdges(t *testing.T) {
 			"cpih1dim1aggid--cpih1dim1A0":     "cpih1dim1A0",
 		}
 		expectedQueries := []string{
-			"g.V().hasLabel('_code').has('value', 'cpih1dim1T90000').has('listID', 'cpih1dim1aggid').as('dest').V('cpih1dim1aggid--cpih1dim1T90000').coalesce(__.outE('hasCode'), __.addE('hasCode').to(select('dest')))",
-			"g.V().hasLabel('_code').has('value', 'cpih1dim1G90400').has('listID', 'cpih1dim1aggid').as('dest').V('cpih1dim1aggid--cpih1dim1G90400').coalesce(__.outE('hasCode'), __.addE('hasCode').to(select('dest')))",
-			"g.V().hasLabel('_code').has('value', 'cpih1dim1A0').has('listID', 'cpih1dim1aggid').as('dest').V('cpih1dim1aggid--cpih1dim1A0').coalesce(__.outE('hasCode'), __.addE('hasCode').to(select('dest')))",
+			"g.V().hasLabel('_code').has('value', 'cpih1dim1T90000').where(out('usedBy').hasLabel('_code_list').has('listID','cpih1dim1aggid')).as('dest').V('cpih1dim1aggid--cpih1dim1T90000').coalesce(__.outE('hasCode'), __.addE('hasCode').to(select('dest')))",
+			"g.V().hasLabel('_code').has('value', 'cpih1dim1G90400').where(out('usedBy').hasLabel('_code_list').has('listID','cpih1dim1aggid')).as('dest').V('cpih1dim1aggid--cpih1dim1G90400').coalesce(__.outE('hasCode'), __.addE('hasCode').to(select('dest')))",
+			"g.V().hasLabel('_code').has('value', 'cpih1dim1A0').where(out('usedBy').hasLabel('_code_list').has('listID','cpih1dim1aggid')).as('dest').V('cpih1dim1aggid--cpih1dim1A0').coalesce(__.outE('hasCode'), __.addE('hasCode').to(select('dest')))",
 		}
 
 		Convey("when CreateHasCodeEdges is successfully called, no error is returned and the expected gremlin queries are executed, in any order", func() {

--- a/neptune/query/query.go
+++ b/neptune/query/query.go
@@ -70,8 +70,10 @@ const (
 	GetGenericHierarchyAncestryIDs = `g.V().hasLabel('_generic_hierarchy_node_%s').has('code',within(%s)).repeat(out('hasParent')).emit().as('gh')` +
 		`.id().as('node_id').select('gh').values('code').as('node_code').select('gh').select('node_id', 'node_code')`
 
-	// crete 'hasCode' edge from a generic hierarchy node to the provided code node, only if it does not exist already
-	CreateHasCodeEdge = `g.V().hasLabel('_code').has('value', '%s').has('listID', '%s').as('dest')` +
+	// crete 'hasCode' edge from a generic hierarchy node to the provided code node, only if it does not exist already:
+	// 1. get code node from code and codelist, this is uniquely determined by the usedBy edge between them
+	// 2. create an 'hasCode' edge between the provided nodeID and the code
+	CreateHasCodeEdge = `g.V().hasLabel('_code').has('value', '%s').where(out('usedBy').hasLabel('_code_list').has('listID','%s')).as('dest')` +
 		`.V('%s').coalesce(__.outE('hasCode'), __.addE('hasCode').to(select('dest')))`
 
 	// GetHierarchyNodeIDs gets the IDs of the cloned hierarchy nodes for a particular instanceID and dimensionName


### PR DESCRIPTION
### What

We can't rely on the listID, intead we need to find it according to usedBy edge and the codelist node at the other end

Example of a situation that triggered the bug:

- We want to get the code node that has value `S13002553` and is used by codeList `administrative-geography`:

- code node with value S13002553:
```
g.V().hasLabel('_code').has('value', 'S13002553').valueMap(true)
==>{listID=[geography], id=_code_geography_S13002553, label=_code, value=[S13002553]}
```

- codelist nodes that have edges with this node:
```
 g.V().hasLabel('_code').has('value', 'S13002553').out('usedBy').valueMap(true)
==>{listID=[administrative-geography], id=_code_list_administrative-geography_one-off, geography=[true], label=_code_list, edition=[one-off], label=[Geography]}
==>{listID=[output-area], id=_code_list_output-area_2011, geography=[true], label=_code_list, edition=[2011], label=[Geography]}
```

Note that the code node has listID that does not match the codeList value. This is because this node is used by multiple codelists, hence there is no way to define a unique codelist value as a property of the code node.

The solution to get the code node by unique {code, codelist} is by checking usedBy edge.


### How to review

- Make sure change makes sense
- Make sure unit tests pass
- This change has been tested with hierarchy builder, with `administrative-geography` codelist (the same dataset that triggered the bug originally)

### Who can review

Anyone
