### PR TITLE
Remove sortDimensions() for Neptune calls.

### DIFF
--- a/neptune/observation.go
+++ b/neptune/observation.go
@@ -3,9 +3,10 @@ package neptune
 import (
 	"context"
 	"fmt"
-	"github.com/ONSdigital/dp-graph/v2/graph/driver"
 	"strings"
 	"time"
+
+	"github.com/ONSdigital/dp-graph/v2/graph/driver"
 
 	"github.com/pkg/errors"
 
@@ -55,58 +56,16 @@ func (n *NeptuneDB) StreamCSVRows(ctx context.Context, instanceID, filterID stri
 	return observation.NewCompositeRowReader(headerReader, observationReader), nil
 }
 
-// sortDimensions takes a list of dimensions and returns them sorted for query performance
-// for now this function will return the geography dimension first, but in future it would be
-// more optimal to return the dimension with the highest cardinality first.
-func sortDimensions(dimensions []*observation.Dimension) (sortedDimensions []*observation.Dimension) {
-
-	if len(dimensions) <= 1 {
-		return dimensions
-	}
-
-	geographyIndex := getGeographyIndex(dimensions)
-
-	// there is no sorting to be done, return original list
-	if geographyIndex == -1 {
-		return dimensions
-	}
-
-	// add geography first
-	sortedDimensions = append(sortedDimensions, dimensions[geographyIndex])
-
-	// then add any other dimensions
-	for i, dimension := range dimensions {
-		if i != geographyIndex {
-			sortedDimensions = append(sortedDimensions, dimension)
-		}
-	}
-
-	return sortedDimensions
-}
-
-func getGeographyIndex(dimensions []*observation.Dimension) int {
-
-	for i, dimension := range dimensions {
-		if strings.ToLower(dimension.Name) == "geography" {
-			return i
-		}
-	}
-
-	return -1
-}
-
 func buildObservationsQuery(instanceID string, f *observation.DimensionFilters) string {
 	if f.IsEmpty() {
 		return fmt.Sprintf(query.GetAllObservationsPart, instanceID)
 	}
 
-	sortedDimensions := sortDimensions(f.Dimensions)
-
 	var q string
 	additionalDimensions := 0
 	var additionalDimensionOptions []string
 
-	for i, dim := range sortedDimensions {
+	for i, dim := range f.Dimensions {
 		if len(dim.Options) == 0 {
 			continue
 		}

--- a/neptune/observation_test.go
+++ b/neptune/observation_test.go
@@ -52,9 +52,9 @@ func Test_buildObservationsQuery(t *testing.T) {
 		instanceID := "888"
 		filter := &observation.DimensionFilters{
 			Dimensions: []*observation.Dimension{
+				{Name: "geography", Options: []string{"K0001", "K0002", "K0003"}},
 				{Name: "age", Options: []string{"29", "30", "31"}},
 				{Name: "sex", Options: []string{"male", "female", "all"}},
-				{Name: "geography", Options: []string{"K0001", "K0002", "K0003"}},
 			},
 		}
 
@@ -316,89 +316,6 @@ func Test_InsertObservationBatch(t *testing.T) {
 
 			Convey("Then the expected error is returned", func() {
 				So(err.Error(), ShouldEqual, "failed to add observation edges: "+expectedErr.Error())
-			})
-		})
-	})
-}
-
-func Test_sortDimensions(t *testing.T) {
-
-	Convey("Given an empty list of dimensions", t, func() {
-		var dimensionOptions []*observation.Dimension
-
-		Convey("When sortDimensions is called", func() {
-			result := sortDimensions(dimensionOptions)
-
-			Convey("Then the same list is returned", func() {
-				So(result, ShouldEqual, dimensionOptions)
-			})
-		})
-	})
-
-	Convey("Given a list of dimensions with 1 dimension", t, func() {
-
-		dimensionOptions := []*observation.Dimension{
-			{Name: "age", Options: []string{"30"}},
-		}
-
-		Convey("When sortDimensions is called", func() {
-			result := sortDimensions(dimensionOptions)
-
-			Convey("Then the same list is returned", func() {
-				So(result, ShouldResemble, dimensionOptions)
-			})
-		})
-	})
-
-	Convey("Given a list of dimensions with 1 geography dimension", t, func() {
-
-		dimensionOptions := []*observation.Dimension{
-			{Name: "geography", Options: []string{"K0001", "K0002", "K0003"}},
-		}
-
-		Convey("When sortDimensions is called", func() {
-			result := sortDimensions(dimensionOptions)
-
-			Convey("Then the same list is returned", func() {
-				So(result, ShouldResemble, dimensionOptions)
-			})
-		})
-	})
-
-	Convey("Given a list of dimensions without a geography dimension", t, func() {
-		dimensionOptions := []*observation.Dimension{
-			{Name: "age", Options: []string{"29", "30", "31"}},
-			{Name: "sex", Options: []string{"male", "female", "all"}},
-			{Name: "time", Options: []string{"2004", "2005", "2006"}},
-		}
-
-		Convey("When sortDimensions is called", func() {
-			result := sortDimensions(dimensionOptions)
-
-			Convey("Then the same list is returned", func() {
-				So(result, ShouldResemble, dimensionOptions)
-			})
-		})
-	})
-
-	Convey("Given a list of dimensions with a geography dimension", t, func() {
-		dimensionOptions := []*observation.Dimension{
-			{Name: "age", Options: []string{"29", "30", "31"}},
-			{Name: "sex", Options: []string{"male", "female", "all"}},
-			{Name: "geography", Options: []string{"K0001", "K0002", "K0003"}},
-		}
-
-		expectedDimensionOptions := []*observation.Dimension{
-			{Name: "geography", Options: []string{"K0001", "K0002", "K0003"}},
-			{Name: "age", Options: []string{"29", "30", "31"}},
-			{Name: "sex", Options: []string{"male", "female", "all"}},
-		}
-
-		Convey("When sortDimensions is called", func() {
-			result := sortDimensions(dimensionOptions)
-
-			Convey("Then the list is returned with the geography dimension first", func() {
-				So(result, ShouldResemble, expectedDimensionOptions)
 			})
 		})
 	})


### PR DESCRIPTION
### What

The sort dimensions is now done by the caller - dp-dataset-exporter, where it can get all dimensions sizes from mongo.

Covering card: https://trello.com/c/ckxkekHr/5079-filter-by-largest-dimension-first

### How to review

Inspect code.
Run tests.

### Who can review

Anyone
