### PR TITLE
Fix/cache concurrency new

### DIFF
--- a/graph/driver/driver.go
+++ b/graph/driver/driver.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"context"
+	"sync"
 
 	"github.com/ONSdigital/dp-graph/v2/models"
 	"github.com/ONSdigital/dp-graph/v2/observation"
@@ -81,5 +82,5 @@ type Instance interface {
 
 // Dimension defines functions to create dimension nodes
 type Dimension interface {
-	InsertDimension(ctx context.Context, cache map[string]string, instanceID string, d *models.Dimension) (*models.Dimension, error)
+	InsertDimension(ctx context.Context, cache map[string]string, cacheMutex *sync.Mutex, instanceID string, d *models.Dimension) (*models.Dimension, error)
 }

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -78,7 +78,7 @@ func Test_NewCodeListStore(t *testing.T) {
 				}, ShouldPanic)
 
 				So(func() {
-					db.InsertDimension(context.Background(), nil, "", nil)
+					db.InsertDimension(context.Background(), nil, nil, "", nil)
 				}, ShouldPanic)
 
 				So(func() {
@@ -115,7 +115,7 @@ func Test_NewHierarchyStore(t *testing.T) {
 				}, ShouldPanic)
 
 				So(func() {
-					db.InsertDimension(context.Background(), nil, "", nil)
+					db.InsertDimension(context.Background(), nil, nil, "", nil)
 				}, ShouldPanic)
 
 				So(func() {
@@ -152,7 +152,7 @@ func Test_NewInstanceStore(t *testing.T) {
 				}, ShouldPanic)
 
 				So(func() {
-					db.InsertDimension(context.Background(), nil, "", nil)
+					db.InsertDimension(context.Background(), nil, nil, "", nil)
 				}, ShouldPanic)
 
 				So(func() {
@@ -189,7 +189,7 @@ func Test_NewObservationStore(t *testing.T) {
 				}, ShouldPanic)
 
 				So(func() {
-					db.InsertDimension(context.Background(), nil, "", nil)
+					db.InsertDimension(context.Background(), nil, nil, "", nil)
 				}, ShouldPanic)
 
 				So(func() {
@@ -230,7 +230,7 @@ func Test_NewDimensionStore(t *testing.T) {
 				}, ShouldPanic)
 
 				So(func() {
-					db.InsertDimension(context.Background(), nil, "", nil)
+					db.InsertDimension(context.Background(), nil, nil, "", nil)
 				}, ShouldNotPanic)
 			})
 		})

--- a/mock/dimension.go
+++ b/mock/dimension.go
@@ -2,10 +2,11 @@ package mock
 
 import (
 	"context"
+	"sync"
 
 	"github.com/ONSdigital/dp-graph/v2/models"
 )
 
-func (m *Mock) InsertDimension(ctx context.Context, cache map[string]string, instanceID string, d *models.Dimension) (*models.Dimension, error) {
+func (m *Mock) InsertDimension(ctx context.Context, cache map[string]string, cacheMutex *sync.Mutex, instanceID string, d *models.Dimension) (*models.Dimension, error) {
 	return nil, m.checkForErrors()
 }

--- a/neo4j/dimensions_test.go
+++ b/neo4j/dimensions_test.go
@@ -3,6 +3,7 @@ package neo4j
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -27,6 +28,47 @@ var expectedDimension = &models.Dimension{
 }
 
 func Test_InsertDimension(t *testing.T) {
+	Convey("Given an empty neo4j mock", t, func() {
+		neo4jMock := &internal.Neo4jDriverMock{}
+		db := &Neo4j{neo4jMock, 5, 30}
+
+		Convey("When Insert is invoked with an empty instanceID", func() {
+			dim, err := db.InsertDimension(context.Background(), map[string]string{}, &sync.Mutex{}, "", dimension)
+
+			Convey("Then the expected error is returned with a nil dimension", func() {
+				So(err.Error(), ShouldEqual, "instance id is required but was empty")
+				So(dim, ShouldBeNil)
+			})
+		})
+
+		Convey("When Insert is invoked with a nil cache map", func() {
+			dim, err := db.InsertDimension(context.Background(), nil, &sync.Mutex{}, instanceID, dimension)
+
+			Convey("Then the expected error is returned with a nil dimension", func() {
+				So(err.Error(), ShouldEqual, "no cache map provided to InsertDimension")
+				So(dim, ShouldBeNil)
+			})
+		})
+
+		Convey("When Insert is invoked with a nil cache mutex", func() {
+			dim, err := db.InsertDimension(context.Background(), map[string]string{}, nil, instanceID, dimension)
+
+			Convey("Then the expected error is returned with a nil dimension", func() {
+				So(err.Error(), ShouldEqual, "no cache mutex provided to InsertDimension")
+				So(dim, ShouldBeNil)
+			})
+		})
+
+		Convey("When Insert is invoked with a nil dimension", func() {
+			dim, err := db.InsertDimension(context.Background(), map[string]string{}, &sync.Mutex{}, instanceID, nil)
+
+			Convey("Then the expected error is returned with a nil dimension", func() {
+				So(err.Error(), ShouldEqual, "dimension is required but was nil")
+				So(dim, ShouldBeNil)
+			})
+		})
+	})
+
 	Convey("Given a dimension type that has already been processed", t, func() {
 		nodeID := new(string)
 		neo4jMock := &internal.Neo4jDriverMock{
@@ -39,9 +81,10 @@ func Test_InsertDimension(t *testing.T) {
 		db := &Neo4j{neo4jMock, 5, 30}
 
 		constraintsCache := map[string]string{"_" + instanceID + "_" + dimension.DimensionID: ""}
+		constraintsCacheMutex := &sync.Mutex{}
 
 		Convey("When Insert is invoked", func() {
-			dim, err := db.InsertDimension(context.Background(), constraintsCache, instanceID, dimension)
+			dim, err := db.InsertDimension(context.Background(), constraintsCache, constraintsCacheMutex, instanceID, dimension)
 			dim.NodeID = *nodeID
 
 			Convey("Then the expected error is returned with a nil dimension", func() {
@@ -82,9 +125,10 @@ func Test_InsertDimension(t *testing.T) {
 		db := &Neo4j{neo4jMock, 5, 30}
 
 		constraintsCache := map[string]string{"_differentID_" + dimension.DimensionID: ""}
+		constraintsCacheMutex := &sync.Mutex{}
 
 		Convey("When Insert is invoked", func() {
-			dim, err := db.InsertDimension(context.Background(), constraintsCache, instanceID, dimension)
+			dim, err := db.InsertDimension(context.Background(), constraintsCache, constraintsCacheMutex, instanceID, dimension)
 			dim.NodeID = *nodeID
 
 			Convey("Then the expected error is returned with a nil dimension", func() {
@@ -127,9 +171,10 @@ func Test_InsertDimension(t *testing.T) {
 		db := &Neo4j{neo4jMock, 5, 30}
 
 		constraintsCache := map[string]string{}
+		constraintsCacheMutex := &sync.Mutex{}
 
 		Convey("When Insert is invoked", func() {
-			dim, err := db.InsertDimension(context.Background(), constraintsCache, instanceID, dimension)
+			dim, err := db.InsertDimension(context.Background(), constraintsCache, constraintsCacheMutex, instanceID, dimension)
 
 			Convey("Then the expected error is returned with a nil dimension", func() {
 				So(dim, ShouldEqual, nil)
@@ -164,9 +209,10 @@ func Test_InsertDimension(t *testing.T) {
 		db := &Neo4j{neo4jMock, 5, 30}
 
 		constraintsCache := map[string]string{"_" + instanceID + "_" + dimension.DimensionID: dimension.DimensionID}
+		constraintsCacheMutex := &sync.Mutex{}
 
 		Convey("When Insert is invoked", func() {
-			dim, err := db.InsertDimension(context.Background(), constraintsCache, instanceID, dimension)
+			dim, err := db.InsertDimension(context.Background(), constraintsCache, constraintsCacheMutex, instanceID, dimension)
 
 			Convey("Then the expected error is returned with a nil dimension", func() {
 				So(dim, ShouldEqual, nil)
@@ -187,6 +233,42 @@ func Test_InsertDimension(t *testing.T) {
 			Convey("And there is no other calls to neo4j", func() {
 				So(len(neo4jMock.ExecCalls()), ShouldEqual, 0)
 			})
+		})
+	})
+}
+
+func TestCacheDimension(t *testing.T) {
+	ctx := context.Background()
+	dimensionLabel := "_inst_dim"
+
+	Convey("Given 2 concurrent go-routines that try to cache a dimension", t, func() {
+		cache := make(map[string]string)
+		cacheMutex := &sync.Mutex{}
+
+		wg := &sync.WaitGroup{}
+		created1 := false
+		created2 := false
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			created1 = cacheDimension(ctx, cache, cacheMutex, dimensionLabel)
+		}()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			created2 = cacheDimension(ctx, cache, cacheMutex, dimensionLabel)
+		}()
+
+		wg.Wait()
+
+		Convey("Then the dimension was cached, created only by one of the two callers", func() {
+			So(cache, ShouldResemble, map[string]string{
+				dimensionLabel: dimensionLabel,
+			})
+			So(created1 || created2, ShouldBeTrue) // at least one created the value
+			So(created1, ShouldNotEqual, created2) // only one created the value
 		})
 	})
 }


### PR DESCRIPTION
### What

- Added a mutex to InsertDimension calls, and use it to make sure only one caller updates the cache map at the same time
- Extended unit tests accordingly

This should fix the issue observed with the dimension importer:
```
fatal error: concurrent map read and map write
```

### How to review

- Make sure code changes make sense
- Make sure unit tests pass


### Who can review
anyone
