### PR TITLE
Fix/cache concurrency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,7 @@ require (
 	github.com/ONSdigital/golang-neo4j-bolt-driver v0.0.0-20210408132126-c2323ff08bf1
 	github.com/ONSdigital/graphson v0.2.0
 	github.com/ONSdigital/gremgo-neptune v1.0.2
-	github.com/ONSdigital/log.go/v2 v2.0.5
-	github.com/fatih/color v1.12.0 // indirect
+	github.com/ONSdigital/log.go/v2 v2.0.9
 	github.com/gofrs/uuid v4.0.0+incompatible // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/mattn/go-isatty v0.0.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,4 @@
 github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
-github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
 github.com/ONSdigital/dp-api-clients-go v1.36.0 h1:bAxGiC2rgmtvLTa5YAKJw6OyO9kZSSCDbvwUDg5r5Oc=
 github.com/ONSdigital/dp-api-clients-go v1.36.0/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
 github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=
@@ -24,11 +23,10 @@ github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQ
 github.com/ONSdigital/log.go v1.0.1-0.20200805145532-1f25087a0744/go.mod h1:y4E9MYC+cV9VfjRD0UBGj8PA7H3wABqQi87/ejrDhYc=
 github.com/ONSdigital/log.go v1.0.1 h1:SZ5wRZAwlt2jQUZ9AUzBB/PL+iG15KapfQpJUdA18/4=
 github.com/ONSdigital/log.go v1.0.1/go.mod h1:dIwSXuvFB5EsZG5x44JhsXZKMd80zlb0DZxmiAtpL4M=
-github.com/ONSdigital/log.go/v2 v2.0.5 h1:kl2lF0vr3BQDwPTAUcarDvX4Um3uE3fjVRfLoHAarBc=
-github.com/ONSdigital/log.go/v2 v2.0.5/go.mod h1:PR7vXrv9dZKUc7SI/0toxBbStk84snmybBnWpe+xY2o=
+github.com/ONSdigital/log.go/v2 v2.0.9 h1:dMtuN89vCP21iRuOBAGInn7ZzxIEGajC3o5pjoicnsY=
+github.com/ONSdigital/log.go/v2 v2.0.9/go.mod h1:VyTDkL82FtiAkaNFaT+bURBhLbP7NsIx4rkVbdpiuEg=
 github.com/facebookgo/freeport v0.0.0-20150612182905-d4adf43b75b9/go.mod h1:uPmAp6Sws4L7+Q/OokbWDAK1ibXYhB3PXFP1kol5hPg=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
-github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.12.0 h1:mRhaKNwANqRgUBGKmnI5ZxEk7QXmjQeCcuYFMX2bfcc=
 github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
@@ -86,7 +84,6 @@ golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210414055047-fe65e336abe0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210603125802-9665404d3644 h1:CA1DEQ4NdKphKeL70tvsWNdT5oFh1lOjihRcEDROi0I=
 golang.org/x/sys v0.0.0-20210603125802-9665404d3644/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/graph/driver/driver.go
+++ b/graph/driver/driver.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"context"
+	"sync"
 
 	"github.com/ONSdigital/dp-graph/v2/models"
 	"github.com/ONSdigital/dp-graph/v2/observation"
@@ -81,5 +82,5 @@ type Instance interface {
 
 // Dimension defines functions to create dimension nodes
 type Dimension interface {
-	InsertDimension(ctx context.Context, cache map[string]string, instanceID string, d *models.Dimension) (*models.Dimension, error)
+	InsertDimension(ctx context.Context, cache map[string]string, cacheMutex *sync.Mutex, instanceID string, d *models.Dimension) (*models.Dimension, error)
 }

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -78,7 +78,7 @@ func Test_NewCodeListStore(t *testing.T) {
 				}, ShouldPanic)
 
 				So(func() {
-					db.InsertDimension(context.Background(), nil, "", nil)
+					db.InsertDimension(context.Background(), nil, nil, "", nil)
 				}, ShouldPanic)
 
 				So(func() {
@@ -115,7 +115,7 @@ func Test_NewHierarchyStore(t *testing.T) {
 				}, ShouldPanic)
 
 				So(func() {
-					db.InsertDimension(context.Background(), nil, "", nil)
+					db.InsertDimension(context.Background(), nil, nil, "", nil)
 				}, ShouldPanic)
 
 				So(func() {
@@ -152,7 +152,7 @@ func Test_NewInstanceStore(t *testing.T) {
 				}, ShouldPanic)
 
 				So(func() {
-					db.InsertDimension(context.Background(), nil, "", nil)
+					db.InsertDimension(context.Background(), nil, nil, "", nil)
 				}, ShouldPanic)
 
 				So(func() {
@@ -189,7 +189,7 @@ func Test_NewObservationStore(t *testing.T) {
 				}, ShouldPanic)
 
 				So(func() {
-					db.InsertDimension(context.Background(), nil, "", nil)
+					db.InsertDimension(context.Background(), nil, nil, "", nil)
 				}, ShouldPanic)
 
 				So(func() {
@@ -230,7 +230,7 @@ func Test_NewDimensionStore(t *testing.T) {
 				}, ShouldPanic)
 
 				So(func() {
-					db.InsertDimension(context.Background(), nil, "", nil)
+					db.InsertDimension(context.Background(), nil, nil, "", nil)
 				}, ShouldNotPanic)
 			})
 		})

--- a/mock/dimension.go
+++ b/mock/dimension.go
@@ -2,10 +2,11 @@ package mock
 
 import (
 	"context"
+	"sync"
 
 	"github.com/ONSdigital/dp-graph/v2/models"
 )
 
-func (m *Mock) InsertDimension(ctx context.Context, cache map[string]string, instanceID string, d *models.Dimension) (*models.Dimension, error) {
+func (m *Mock) InsertDimension(ctx context.Context, cache map[string]string, cacheMutex *sync.Mutex, instanceID string, d *models.Dimension) (*models.Dimension, error) {
 	return nil, m.checkForErrors()
 }

--- a/neo4j/dimensions_test.go
+++ b/neo4j/dimensions_test.go
@@ -3,6 +3,7 @@ package neo4j
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -27,6 +28,47 @@ var expectedDimension = &models.Dimension{
 }
 
 func Test_InsertDimension(t *testing.T) {
+	Convey("Given an empty neo4j mock", t, func() {
+		neo4jMock := &internal.Neo4jDriverMock{}
+		db := &Neo4j{neo4jMock, 5, 30}
+
+		Convey("When Insert is invoked with an empty instanceID", func() {
+			dim, err := db.InsertDimension(context.Background(), map[string]string{}, &sync.Mutex{}, "", dimension)
+
+			Convey("Then the expected error is returned with a nil dimension", func() {
+				So(err.Error(), ShouldEqual, "instance id is required but was empty")
+				So(dim, ShouldBeNil)
+			})
+		})
+
+		Convey("When Insert is invoked with a nil cache map", func() {
+			dim, err := db.InsertDimension(context.Background(), nil, &sync.Mutex{}, instanceID, dimension)
+
+			Convey("Then the expected error is returned with a nil dimension", func() {
+				So(err.Error(), ShouldEqual, "no cache map provided to InsertDimension")
+				So(dim, ShouldBeNil)
+			})
+		})
+
+		Convey("When Insert is invoked with a nil cache mutex", func() {
+			dim, err := db.InsertDimension(context.Background(), map[string]string{}, nil, instanceID, dimension)
+
+			Convey("Then the expected error is returned with a nil dimension", func() {
+				So(err.Error(), ShouldEqual, "no cache mutex provided to InsertDimension")
+				So(dim, ShouldBeNil)
+			})
+		})
+
+		Convey("When Insert is invoked with a nil dimension", func() {
+			dim, err := db.InsertDimension(context.Background(), map[string]string{}, &sync.Mutex{}, instanceID, nil)
+
+			Convey("Then the expected error is returned with a nil dimension", func() {
+				So(err.Error(), ShouldEqual, "dimension is required but was nil")
+				So(dim, ShouldBeNil)
+			})
+		})
+	})
+
 	Convey("Given a dimension type that has already been processed", t, func() {
 		nodeID := new(string)
 		neo4jMock := &internal.Neo4jDriverMock{
@@ -39,9 +81,10 @@ func Test_InsertDimension(t *testing.T) {
 		db := &Neo4j{neo4jMock, 5, 30}
 
 		constraintsCache := map[string]string{"_" + instanceID + "_" + dimension.DimensionID: ""}
+		constraintsCacheMutex := &sync.Mutex{}
 
 		Convey("When Insert is invoked", func() {
-			dim, err := db.InsertDimension(context.Background(), constraintsCache, instanceID, dimension)
+			dim, err := db.InsertDimension(context.Background(), constraintsCache, constraintsCacheMutex, instanceID, dimension)
 			dim.NodeID = *nodeID
 
 			Convey("Then the expected error is returned with a nil dimension", func() {
@@ -82,9 +125,10 @@ func Test_InsertDimension(t *testing.T) {
 		db := &Neo4j{neo4jMock, 5, 30}
 
 		constraintsCache := map[string]string{"_differentID_" + dimension.DimensionID: ""}
+		constraintsCacheMutex := &sync.Mutex{}
 
 		Convey("When Insert is invoked", func() {
-			dim, err := db.InsertDimension(context.Background(), constraintsCache, instanceID, dimension)
+			dim, err := db.InsertDimension(context.Background(), constraintsCache, constraintsCacheMutex, instanceID, dimension)
 			dim.NodeID = *nodeID
 
 			Convey("Then the expected error is returned with a nil dimension", func() {
@@ -127,9 +171,10 @@ func Test_InsertDimension(t *testing.T) {
 		db := &Neo4j{neo4jMock, 5, 30}
 
 		constraintsCache := map[string]string{}
+		constraintsCacheMutex := &sync.Mutex{}
 
 		Convey("When Insert is invoked", func() {
-			dim, err := db.InsertDimension(context.Background(), constraintsCache, instanceID, dimension)
+			dim, err := db.InsertDimension(context.Background(), constraintsCache, constraintsCacheMutex, instanceID, dimension)
 
 			Convey("Then the expected error is returned with a nil dimension", func() {
 				So(dim, ShouldEqual, nil)
@@ -164,9 +209,10 @@ func Test_InsertDimension(t *testing.T) {
 		db := &Neo4j{neo4jMock, 5, 30}
 
 		constraintsCache := map[string]string{"_" + instanceID + "_" + dimension.DimensionID: dimension.DimensionID}
+		constraintsCacheMutex := &sync.Mutex{}
 
 		Convey("When Insert is invoked", func() {
-			dim, err := db.InsertDimension(context.Background(), constraintsCache, instanceID, dimension)
+			dim, err := db.InsertDimension(context.Background(), constraintsCache, constraintsCacheMutex, instanceID, dimension)
 
 			Convey("Then the expected error is returned with a nil dimension", func() {
 				So(dim, ShouldEqual, nil)
@@ -187,6 +233,42 @@ func Test_InsertDimension(t *testing.T) {
 			Convey("And there is no other calls to neo4j", func() {
 				So(len(neo4jMock.ExecCalls()), ShouldEqual, 0)
 			})
+		})
+	})
+}
+
+func TestCacheDimension(t *testing.T) {
+	ctx := context.Background()
+	dimensionLabel := "_inst_dim"
+
+	Convey("Given 2 concurrent go-routines that try to cache a dimension", t, func() {
+		cache := make(map[string]string)
+		cacheMutex := &sync.Mutex{}
+
+		wg := &sync.WaitGroup{}
+		created1 := false
+		created2 := false
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			created1 = cacheDimension(ctx, cache, cacheMutex, dimensionLabel)
+		}()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			created2 = cacheDimension(ctx, cache, cacheMutex, dimensionLabel)
+		}()
+
+		wg.Wait()
+
+		Convey("Then the dimension was cached, created only by one of the two callers", func() {
+			So(cache, ShouldResemble, map[string]string{
+				dimensionLabel: dimensionLabel,
+			})
+			So(created1 || created2, ShouldBeTrue) // at least one created the value
+			So(created1, ShouldNotEqual, created2) // only one created the value
 		})
 	})
 }


### PR DESCRIPTION
### What

- Added a mutex to InsertDimension calls, and use it to make sure only one caller updates the cache map at the same time
- Extended unit tests accordingly

This should fix the issue observed with the dimension importer:
```
fatal error: concurrent map read and map write
```

### How to review

- Make sure code changes make sense
- Make sure unit tests pass


### Who can review
anyone
