### PR TITLE
Fix issue in Neptune query caused by `is_(`

### DIFF
--- a/neptune/observation_test.go
+++ b/neptune/observation_test.go
@@ -62,7 +62,7 @@ func Test_buildObservationsQuery(t *testing.T) {
 			result := buildObservationsQuery(instanceID, filter)
 
 			Convey("Then the resulting query portion should filter to relevant observations", func() {
-				expectedQuery := `g.V().hasId('_888_geography_K0001','_888_geography_K0002','_888_geography_K0003').in('isValueOf').where(out('isValueOf').hasId('_888_age_29','_888_age_30','_888_age_31','_888_sex_male','_888_sex_female','_888_sex_all').fold().count(local).is_(2))`
+				expectedQuery := `g.V().hasId('_888_geography_K0001','_888_geography_K0002','_888_geography_K0003').in('isValueOf').where(out('isValueOf').hasId('_888_age_29','_888_age_30','_888_age_31','_888_sex_male','_888_sex_female','_888_sex_all').fold().count(local).is(2))`
 				So(result, ShouldEqual, expectedQuery)
 			})
 		})

--- a/neptune/query/query.go
+++ b/neptune/query/query.go
@@ -200,7 +200,7 @@ const (
 	GetInstanceHeaderPart       = `g.V().hasId('_%s_Instance').values('header')`
 	GetAllObservationsPart      = `g.V().hasLabel('_%s_observation')`
 	GetFirstDimensionPart       = `g.V().hasId(%s).in('isValueOf')`
-	GetAdditionalDimensionsPart = `.where(out('isValueOf').hasId(%s).fold().count(local).is_(%d))`
+	GetAdditionalDimensionsPart = `.where(out('isValueOf').hasId(%s).fold().count(local).is(%d))`
 	GetObservationValuesPart    = `.values('value')`
 	LimitPart                   = `.limit(%d)`
 )


### PR DESCRIPTION
### What

Upgraded Neptune instances do not recognise queries with `.in_(`. Replaced with `.in(` for compatibility.

### How to review

Tested already by @s-xton @sandypadmanabhan and @jessjenkins 
Ensure only the one char changed as expected and tests pass

### Who can review

Anyone but me