### PR TITLE
Add ability to configure TLS verification for local running

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,22 @@ A library to abstract graph database logic away from services
 | GRAPH_ADDR           |   ""    |  address of the database matching the chosen driver type
 | GRAPH_POOL_SIZE      |   0     |  desired size of the connection pool
 | MAX_RETRIES          |   0     |  maximum number of attempts for transient query failures
+| RETRY_TIME           |   20ms for Neptune    |  the initial sleep time between requests in the `retry` package
 | GRAPH_QUERY_TIMEOUT  |   0     |  maximum number of seconds to allow a query before timing out
 
 All config other than `GRAPH_DRIVER_TYPE` will be subject to that implementation to make use of
 and set reasonable defaults for use in that context. It's feasible that some implementations
 might not have configurable timeouts for example, so whether this can be set should be
 documented in each driver.
+
+#### Neptune specific configuration
+
+| Environment variable      | Default  | Description
+| --------------------      | -------  | -----------
+| NEPTUNE_BATCH_SIZE_READER |   25000  |  batch size for queries to a reader endpoint
+| NEPTUNE_BATCH_SIZE_WRITER |   150    |  batch size for queries to a writer endpoint
+| NEPTUNE_MAX_WORKERS       |   150    |  maximum number of workers in the Neptune pool
+| NEPTUNE_TLS_SKIP_VERIFY   |   false  |  flag to skip TLS certificate verification, should only be `true` when run locally
 
 ### Design
 

--- a/config/config.go
+++ b/config/config.go
@@ -27,9 +27,10 @@ type Configuration struct {
 
 // NeptuneConfig defines the neptune-specific configuration
 type NeptuneConfig struct {
-	BatchSizeReader int `envconfig:"NEPTUNE_BATCH_SIZE_READER"`
-	BatchSizeWriter int `envconfig:"NEPTUNE_BATCH_SIZE_WRITER"`
-	MaxWorkers      int `envconfig:"NEPTUNE_MAX_WORKERS"`
+	BatchSizeReader int  `envconfig:"NEPTUNE_BATCH_SIZE_READER"`
+	BatchSizeWriter int  `envconfig:"NEPTUNE_BATCH_SIZE_WRITER"`
+	MaxWorkers      int  `envconfig:"NEPTUNE_MAX_WORKERS"`
+	TLSSkipVerify   bool `envconfig:"NEPTUNE_TLS_SKIP_VERIFY"`
 }
 
 var cfg *Configuration
@@ -46,6 +47,7 @@ func Get(errs chan error) (*Configuration, error) {
 			BatchSizeReader: 25000,
 			BatchSizeWriter: 150,
 			MaxWorkers:      150,
+			TLSSkipVerify:   false,
 		},
 	}
 
@@ -68,6 +70,7 @@ func Get(errs chan error) (*Configuration, error) {
 			cfg.Neptune.BatchSizeReader,
 			cfg.Neptune.BatchSizeWriter,
 			cfg.Neptune.MaxWorkers,
+			cfg.Neptune.TLSSkipVerify,
 			cfg.RetryTime,
 			errs)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ONSdigital/dp-healthcheck v1.6.1
 	github.com/ONSdigital/golang-neo4j-bolt-driver v0.0.0-20210408132126-c2323ff08bf1
 	github.com/ONSdigital/graphson v0.3.0
-	github.com/ONSdigital/gremgo-neptune v1.0.3
+	github.com/ONSdigital/gremgo-neptune v1.1.0
 	github.com/ONSdigital/log.go/v2 v2.4.1
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 
 require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.252.0 // indirect
-	github.com/ONSdigital/dp-net/v2 v2.9.1 // indirect
+	github.com/ONSdigital/dp-net/v2 v2.11.0 // indirect
 	github.com/fatih/color v1.15.0 // indirect
 	github.com/gofrs/uuid v4.4.0+incompatible // indirect
 	github.com/gopherjs/gopherjs v1.17.2 // indirect
@@ -25,5 +25,5 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.18 // indirect
 	github.com/smartystreets/assertions v1.13.1 // indirect
-	golang.org/x/sys v0.6.0 // indirect
+	golang.org/x/sys v0.11.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/ONSdigital/dp-api-clients-go/v2 v2.252.0 h1:lV+ENoQURWYx1BqAaRhiGV/yT
 github.com/ONSdigital/dp-api-clients-go/v2 v2.252.0/go.mod h1:p49IHBmIH5fbAHJ1PrqGbtoHS45jfkYQZeRuIB+CgPQ=
 github.com/ONSdigital/dp-healthcheck v1.6.1 h1:YDAnxE2fI3G2hhGC42mKI/fRhAhIYmFZGQwQ/8M65M0=
 github.com/ONSdigital/dp-healthcheck v1.6.1/go.mod h1:FURB2RUJHw3lssamKtsGsrbu31ar9yhMSDYzG9vgSIo=
-github.com/ONSdigital/dp-net/v2 v2.9.1 h1:2hGa0ArL0m2pMT9cFxMPcSOgvJ0zstH3NxWeykU9Elg=
-github.com/ONSdigital/dp-net/v2 v2.9.1/go.mod h1:iy1XmnqC7aKwHCpbTDhfAVrlYDGJGkZl36zeXyHq+Hw=
+github.com/ONSdigital/dp-net/v2 v2.11.0 h1:XXst84GpXhBiyKoqLuohR7CvzrCBfSkq6YsveTarlt4=
+github.com/ONSdigital/dp-net/v2 v2.11.0/go.mod h1:4T3GgoonNt2nZZJJer9cx7j/3XGJ1UhTp16flx+uDeA=
 github.com/ONSdigital/golang-neo4j-bolt-driver v0.0.0-20210408132126-c2323ff08bf1 h1:xfcuXZ7tM8EL2Y+gSKW59JNN5ID6vhOaXO/MlN6m7xU=
 github.com/ONSdigital/golang-neo4j-bolt-driver v0.0.0-20210408132126-c2323ff08bf1/go.mod h1:75Sxr59AMz2RiPskqSymLFxdeaIEhnkNaJE5lonMS3M=
 github.com/ONSdigital/graphson v0.3.0 h1:s59Qx6RgC4IlqIvjXLD1NWpMGQ8tKIUaJGqnjuy8Zxk=
@@ -39,5 +39,6 @@ github.com/smartystreets/assertions v1.13.1/go.mod h1:cXr/IwVfSo/RbCSPhoAPv73p3h
 github.com/smartystreets/goconvey v1.8.0 h1:Oi49ha/2MURE0WexF052Z0m+BNSGirfjg5RL+JXWq3w=
 github.com/smartystreets/goconvey v1.8.0/go.mod h1:EdX8jtrTIj26jmjCOVNMVSIYAtgexqXKHOXW2Dx9JLg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
+golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/ONSdigital/golang-neo4j-bolt-driver v0.0.0-20210408132126-c2323ff08bf
 github.com/ONSdigital/golang-neo4j-bolt-driver v0.0.0-20210408132126-c2323ff08bf1/go.mod h1:75Sxr59AMz2RiPskqSymLFxdeaIEhnkNaJE5lonMS3M=
 github.com/ONSdigital/graphson v0.3.0 h1:s59Qx6RgC4IlqIvjXLD1NWpMGQ8tKIUaJGqnjuy8Zxk=
 github.com/ONSdigital/graphson v0.3.0/go.mod h1:CimOliQd5p4nPFoncFl4uXguGczYzjHIfdf8YxFm1BQ=
+github.com/ONSdigital/gremgo-neptune v1.1.0 h1:M//UNGPy+OBatFBGBVWFVzdJD/UkRmNbwR/cV4b9lb0=
+github.com/ONSdigital/gremgo-neptune v1.1.0/go.mod h1:OC8qe/RRo+5Grdmrb3bcjEKntBEKH+SGmp1yG3twn5Y=
 github.com/ONSdigital/log.go/v2 v2.4.1 h1:QAHQqtXgXx43OUTSebNAocVfN21RwrHzagN6zDAzwdo=
 github.com/ONSdigital/log.go/v2 v2.4.1/go.mod h1:hJTjxs9r8k49maNelGpL4SBWv8NG45vCKp15+6ce9bw=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ github.com/ONSdigital/golang-neo4j-bolt-driver v0.0.0-20210408132126-c2323ff08bf
 github.com/ONSdigital/golang-neo4j-bolt-driver v0.0.0-20210408132126-c2323ff08bf1/go.mod h1:75Sxr59AMz2RiPskqSymLFxdeaIEhnkNaJE5lonMS3M=
 github.com/ONSdigital/graphson v0.3.0 h1:s59Qx6RgC4IlqIvjXLD1NWpMGQ8tKIUaJGqnjuy8Zxk=
 github.com/ONSdigital/graphson v0.3.0/go.mod h1:CimOliQd5p4nPFoncFl4uXguGczYzjHIfdf8YxFm1BQ=
-github.com/ONSdigital/gremgo-neptune v1.0.3 h1:EPeEwSY7wI+FFDLczgwcyKDuon0FWF35KiWu3RhjSHI=
-github.com/ONSdigital/gremgo-neptune v1.0.3/go.mod h1:OC8qe/RRo+5Grdmrb3bcjEKntBEKH+SGmp1yG3twn5Y=
 github.com/ONSdigital/log.go/v2 v2.4.1 h1:QAHQqtXgXx43OUTSebNAocVfN21RwrHzagN6zDAzwdo=
 github.com/ONSdigital/log.go/v2 v2.4.1/go.mod h1:hJTjxs9r8k49maNelGpL4SBWv8NG45vCKp15+6ce9bw=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=

--- a/neptune/driver/driver.go
+++ b/neptune/driver/driver.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"context"
+	"crypto/tls"
 
 	"github.com/ONSdigital/dp-graph/v2/graph/driver"
 
@@ -15,8 +16,9 @@ type NeptuneDriver struct {
 	Pool NeptunePool // Defined with an interface to support mocking.
 }
 
-func New(ctx context.Context, dbAddr string, errs chan error) (*NeptuneDriver, error) {
-	pool := gremgo.NewPoolWithDialerCtx(ctx, dbAddr, errs)
+func New(ctx context.Context, dbAddr string, errs chan error, tlsSkip bool) (*NeptuneDriver, error) {
+	tConf := &tls.Config{InsecureSkipVerify: tlsSkip}
+	pool := gremgo.NewPoolWithDialerCtx(ctx, dbAddr, errs, gremgo.SetTLSClientConfig(tConf))
 	return &NeptuneDriver{
 		Pool: pool,
 	}, nil

--- a/neptune/neptune.go
+++ b/neptune/neptune.go
@@ -26,7 +26,7 @@ type NeptuneDB struct {
 	maxWorkers      int
 }
 
-func New(dbAddr string, size, timeout, retries, batchSizeReader, batchSizeWriter, maxWorkers int, retryTime time.Duration, errs chan error) (n *NeptuneDB, err error) {
+func New(dbAddr string, size, timeout, retries, batchSizeReader, batchSizeWriter, maxWorkers int, tlsSkip bool, retryTime time.Duration, errs chan error) (n *NeptuneDB, err error) {
 	// set defaults if not provided
 	if size == 0 {
 		size = 30
@@ -51,7 +51,7 @@ func New(dbAddr string, size, timeout, retries, batchSizeReader, batchSizeWriter
 	}
 
 	var d *neptune.NeptuneDriver
-	if d, err = neptune.New(context.Background(), dbAddr, errs); err != nil {
+	if d, err = neptune.New(context.Background(), dbAddr, errs, tlsSkip); err != nil {
 		return
 	}
 


### PR DESCRIPTION
### What

Add NEPTUNE_TLS_SKIP_VERIFY variable to the dp-graph NeptuneConfig struct and pass this value through to the Neptune package. This defaults to false to ensure TLS verification happens by default, but needs to be overwritten to 'true' for local running.

Update the Neptune driver to use this value to build a TLS Config object and pass this through to the underlying gremgo-neptune library which configures the TLS connection.

Things are split this way so that if we needed to further configure the TLS connection in the future, we would not need to update gremgo again, but keeps the config as simple as possible at the dp-graph level.

### How to review

Using this version of gremgo-neptune: https://github.com/ONSdigital/gremgo-neptune/pull/16
Update the go.mod for this repo to contain something like `replace github.com/ONSdigital/gremgo-neptune => /Users/your/local/structure/gremgo-neptune` after go 1.19
Update the dataset API to relpace both dp-graph and gremgo-neptune in its' dependencies, export NEPTUNE_TLS_SKIP_VERIFY=true and run the dataset api

If this works, then we have a working solution!
Worth testing this if the dataset API is running in a Docker container as well
Also does the code change actually make sense? :) 


### Who can review

@lindenmckenzie 
