### PR TITLE
replaced occurrences of incr to asc in gremlin queries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,5 +25,6 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.18 // indirect
 	github.com/smartystreets/assertions v1.13.1 // indirect
-	golang.org/x/sys v0.11.0 // indirect
+	golang.org/x/net v0.27.0 // indirect
+	golang.org/x/sys v0.22.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -38,7 +38,11 @@ github.com/smartystreets/assertions v1.13.1 h1:Ef7KhSmjZcK6AVf9YbJdvPYG9avaF0Zxu
 github.com/smartystreets/assertions v1.13.1/go.mod h1:cXr/IwVfSo/RbCSPhoAPv73p3hlSdrBH/b3SdnW/LMY=
 github.com/smartystreets/goconvey v1.8.0 h1:Oi49ha/2MURE0WexF052Z0m+BNSGirfjg5RL+JXWq3w=
 github.com/smartystreets/goconvey v1.8.0/go.mod h1:EdX8jtrTIj26jmjCOVNMVSIYAtgexqXKHOXW2Dx9JLg=
+golang.org/x/net v0.27.0 h1:5K3Njcw06/l2y9vpGCSdcxWOYHOUk3dVNGDXN+FvAys=
+golang.org/x/net v0.27.0/go.mod h1:dDi0PyhWNoiUOrAS8uXv/vnScO4wnHQO4mj9fn/RytE=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
+golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/neptune/codelists_test.go
+++ b/neptune/codelists_test.go
@@ -360,7 +360,7 @@ func TestGetCodes(t *testing.T) {
 		Convey("When GetCodes() is called", func() {
 			_, err := db.GetCodes(context.Background(), unusedCodeListID, unusedEdition)
 			expectedErr := `Gremlin query failed: "g.V().has('_code_list','listID', 'unused-id').has('edition', 'unused-edition').` +
-				`inE('usedBy').as('usedBy').outV().order().by('value',incr).as('code').select('usedBy', 'code').by('label').by('value').` +
+				`inE('usedBy').as('usedBy').outV().order().by('value',asc).as('code').select('usedBy', 'code').by('label').by('value').` +
 				`unfold().select(values)":  MALFORMED REQUEST `
 			Convey("Then the returned error should wrap the underlying one containing the unsorted query", func() {
 				So(err.Error(), ShouldEqual, expectedErr)
@@ -377,7 +377,7 @@ func TestGetCodes(t *testing.T) {
 		Convey("When GetCodes() is called", func() {
 			_, err := db.GetCodes(context.Background(), unusedCodeListID, unusedEdition)
 			expectedErr := `Gremlin query failed: "g.V().has('_code_list', 'listID', 'unused-id').has('edition', 'unused-edition').` +
-				`inE('usedBy').order().by('order',incr).as('usedBy').outV().as('code').select('usedBy', 'code').by('label').by('value').` +
+				`inE('usedBy').order().by('order',asc).as('usedBy').outV().as('code').select('usedBy', 'code').by('label').by('value').` +
 				`unfold().select(values)":  MALFORMED REQUEST `
 			Convey("Then the returned error should wrap the underlying one containing the sorted query", func() {
 				So(err.Error(), ShouldEqual, expectedErr)
@@ -431,7 +431,7 @@ func TestGetCodes(t *testing.T) {
 				Convey("With a well formed query string", func() {
 					expectedQry := `g.V().has('_code_list','listID', 'unused-id').has('edition', 'unused-edition').` +
 						`inE('usedBy').as('usedBy').` +
-						`outV().order().by('value',incr).as('code').` +
+						`outV().order().by('value',asc).as('code').` +
 						`select('usedBy', 'code').by('label').by('value').` +
 						`unfold().select(values)`
 					actualQry := calls[0].Query
@@ -465,7 +465,7 @@ func TestGetCodes(t *testing.T) {
 				So(len(calls), ShouldEqual, 1)
 				Convey("With a well formed query string", func() {
 					expectedQry := `g.V().has('_code_list', 'listID', 'unused-id').has('edition', 'unused-edition').` +
-						`inE('usedBy').order().by('order',incr).as('usedBy').` +
+						`inE('usedBy').order().by('order',asc).as('usedBy').` +
 						`outV().as('code').` +
 						`select('usedBy', 'code').by('label').by('value').` +
 						`unfold().select(values)`

--- a/neptune/mapper_test.go
+++ b/neptune/mapper_test.go
@@ -85,7 +85,7 @@ func Test_buildHierarchyNode(t *testing.T) {
 		// expected gremlin queries
 		var (
 			expectedCountQuery             = "g.V().hasLabel('_hierarchy_node_instance-id_dimension').has('code','code').in('hasParent').has('order').count()"
-			expectedGetWithOrderQuery      = "g.V().hasLabel('_hierarchy_node_instance-id_dimension').has('code','code').in('hasParent').order().by('order',incr)"
+			expectedGetWithOrderQuery      = "g.V().hasLabel('_hierarchy_node_instance-id_dimension').has('code','code').in('hasParent').order().by('order',asc)"
 			expectedGetAlphabeticallyQuery = "g.V().hasLabel('_hierarchy_node_instance-id_dimension').has('code','code').in('hasParent').order().by('label')"
 			expectedGetAncestryQuery       = "g.V().hasLabel('_hierarchy_node_instance-id_dimension').has('code', 'code').repeat(out('hasParent')).emit()"
 		)

--- a/neptune/query/query.go
+++ b/neptune/query/query.go
@@ -17,11 +17,11 @@ const (
 	CountOrderedEdges      = `g.V().has('_code_list','listID', '%s').has('edition', '%s').inE('usedBy').has('order').count()`
 	GetCodesAlphabetically = `g.V().has('_code_list','listID', '%s').has('edition', '%s')` +
 		`.inE('usedBy').as('usedBy')` +
-		`.outV().order().by('value',incr).as('code')` +
+		`.outV().order().by('value',asc).as('code')` +
 		`.select('usedBy', 'code').by('label').by('value')` +
 		`.unfold().select(values)`
 	GetCodesWithOrder = `g.V().has('_code_list', 'listID', '%s').has('edition', '%s')` +
-		`.inE('usedBy').order().by('order',incr).as('usedBy')` +
+		`.inE('usedBy').order().by('order',asc).as('usedBy')` +
 		`.outV().as('code')` +
 		`.select('usedBy', 'code').by('label').by('value')` +
 		`.unfold().select(values)`
@@ -159,7 +159,7 @@ const (
 	GetHierarchyElement       = `g.V().hasLabel('_hierarchy_node_%s_%s').has('code','%s')`
 	CountChildrenWithOrder    = `g.V().hasLabel('_hierarchy_node_%s_%s').has('code','%s').in('hasParent').has('order').count()`
 	GetChildrenAlphabetically = `g.V().hasLabel('_hierarchy_node_%s_%s').has('code','%s').in('hasParent').order().by('label')`
-	GetChildrenWithOrder      = `g.V().hasLabel('_hierarchy_node_%s_%s').has('code','%s').in('hasParent').order().by('order',incr)`
+	GetChildrenWithOrder      = `g.V().hasLabel('_hierarchy_node_%s_%s').has('code','%s').in('hasParent').order().by('order',asc)`
 	// Note this query is recursive
 	GetAncestry = `g.V().hasLabel('_hierarchy_node_%s_%s').has('code', '%s').repeat(out('hasParent')).emit()`
 


### PR DESCRIPTION
### What

The use of `incr` has been deprecated and removed in the recent version of Gremlin 

### How to review

just a sanity check. or you can log in to gremlin and run the command

### Who can review

Describe who worked on the changes, so that other people can review.
